### PR TITLE
fix: normalize language codes in toTesseract() to handle underscore format

### DIFF
--- a/Packages/TRexCore/Sources/TRexCore/LanguageCodeMapper.swift
+++ b/Packages/TRexCore/Sources/TRexCore/LanguageCodeMapper.swift
@@ -36,6 +36,7 @@ public enum LanguageCodeMapper {
 
     /// Maps standard language codes (e.g., "en-US") to Tesseract language codes (e.g., "eng")
     public static func toTesseract(_ code: String) -> String {
+        let normalizedCode = code.replacingOccurrences(of: "_", with: "-")
         let mapping: [String: String] = [
             // Common languages with region codes
             "en-US": "eng", "en": "eng",
@@ -149,7 +150,7 @@ public enum LanguageCodeMapper {
             "yo": "yor"   // Yoruba
         ]
 
-        return mapping[code] ?? code
+        return mapping[normalizedCode] ?? normalizedCode
     }
     
     /// Maps Tesseract language codes (e.g., "eng") to standard language codes (e.g., "en-US")


### PR DESCRIPTION
## Summary

Fixes Hebrew (and other language) download failures in Tesseract OCR settings.

## Problem

When attempting to download Hebrew language support, users receive:

```
Tesseract initialization failed: Language not supported: he_IL
```

## Root Cause

Apple's `Locale.identifier(fromComponents:)` returns identifiers in POSIX/ICU format with **underscores** (e.g., `he_IL`), but the `LanguageCodeMapper.toTesseract()` mapping dictionary uses **hyphens** (e.g., `he-IL`).

### Data Flow:
1. `LanguageManager.normalizeIdentifier()` calls `Locale.identifier(fromComponents:)` → returns `he_IL`
2. `LanguageCodeMapper.toTesseract("he_IL")` searches for `he_IL` in mapping
3. Mapping only contains `he-IL` → no match → returns `he_IL` unchanged → download fails

## Fix

Normalize input codes by replacing underscores with hyphens before dictionary lookup:

```swift
let normalizedCode = code.replacingOccurrences(of: "_", with: "-")
return mapping[normalizedCode] ?? normalizedCode
```

## Testing

- Verified Hebrew language now downloads successfully
- Build succeeds with no warnings