### PR TITLE
fix: route Custom LLM provider through OpenAI-compatible endpoint

### DIFF
--- a/Packages/TRexLLM/Sources/TRexLLM/Providers/UnifiedLanguageModelProvider.swift
+++ b/Packages/TRexLLM/Sources/TRexLLM/Providers/UnifiedLanguageModelProvider.swift
@@ -49,20 +49,29 @@ public class UnifiedLanguageModelProvider: LLMProvider {
             )
 
         case .custom:
-            self.name = "Ollama"
-            self.supportedModels = ["llama3.2", "llama3.2-vision", "qwen3", "mistral"]
+            self.name = "Custom (OpenAI-compatible)"
+            self.supportedModels = ["llama3.2", "qwen3", "mistral"]
 
+            // OpenAI-compatible servers (LM Studio, Ollama, vLLM, etc.) expose
+            // a /chat/completions endpoint. Default to Ollama's local OpenAI
+            // bridge so a bare install still talks to a local server.
+            let baseURL: URL
             if let customEndpoint = endpoint, !customEndpoint.isEmpty {
-                self.model = OllamaLanguageModel(
-                    baseURL: URL(string: customEndpoint)!,
-                    model: modelName
-                )
+                guard let url = URL(string: customEndpoint) else {
+                    throw LLMError.invalidEndpoint
+                }
+                baseURL = url
             } else {
-                // Default Ollama endpoint
-                self.model = OllamaLanguageModel(
-                    model: modelName
-                )
+                baseURL = URL(string: "http://localhost:11434/v1")!
             }
+
+            // Local servers ignore the key; remote ones (OpenRouter, hosted
+            // vLLM) require it, so forward whatever the user configured.
+            self.model = OpenAILanguageModel(
+                baseURL: baseURL,
+                apiKey: apiKey ?? "",
+                model: modelName
+            )
 
         case .apple:
             self.name = "Apple Foundation Models"

--- a/Packages/TRexLLM/Tests/TRexLLMTests/LLMProviderIntegrationTests.swift
+++ b/Packages/TRexLLM/Tests/TRexLLMTests/LLMProviderIntegrationTests.swift
@@ -112,6 +112,64 @@ final class LLMProviderIntegrationTests: XCTestCase {
         }
     }
 
+    // MARK: - Custom (OpenAI-compatible) Provider
+
+    func testCustomProviderInitialization() throws {
+        // LM Studio / Ollama / vLLM speak the OpenAI dialect; the custom
+        // provider must initialize against an OpenAI-compatible endpoint.
+        let provider = try UnifiedLanguageModelProvider(
+            providerType: .custom,
+            apiKey: nil,
+            endpoint: "http://localhost:1234/v1",
+            modelName: "local-model"
+        )
+
+        XCTAssertEqual(provider.name, "Custom (OpenAI-compatible)")
+    }
+
+    func testCustomProviderInitializesWithoutEndpoint() throws {
+        // A bare configuration should fall back to a local default rather
+        // than failing to construct.
+        let provider = try UnifiedLanguageModelProvider(
+            providerType: .custom,
+            apiKey: nil,
+            endpoint: nil,
+            modelName: "local-model"
+        )
+
+        XCTAssertEqual(provider.name, "Custom (OpenAI-compatible)")
+    }
+
+    func testCustomProviderInitializesWithAPIKey() throws {
+        // Hosted OpenAI-compatible services (OpenRouter, hosted vLLM) require
+        // a key, so it must be accepted when provided.
+        let provider = try UnifiedLanguageModelProvider(
+            providerType: .custom,
+            apiKey: "sk-test-key",
+            endpoint: "https://openrouter.ai/api/v1",
+            modelName: "meta-llama/llama-3.2-3b-instruct"
+        )
+
+        XCTAssertEqual(provider.name, "Custom (OpenAI-compatible)")
+    }
+
+    func testCustomProviderRejectsMalformedEndpoint() {
+        XCTAssertThrowsError(
+            try UnifiedLanguageModelProvider(
+                providerType: .custom,
+                apiKey: nil,
+                endpoint: "http://has space/v1",
+                modelName: "local-model"
+            )
+        ) { error in
+            if case LLMError.invalidEndpoint = error {
+                // Expected
+            } else {
+                XCTFail("Expected invalidEndpoint error, got: \(error)")
+            }
+        }
+    }
+
     // MARK: - Text Processing (OpenAI)
 
     func testOpenAITextProcessing() async throws {

--- a/TRex/App/UI/Settings/LLMSettingsView.swift
+++ b/TRex/App/UI/Settings/LLMSettingsView.swift
@@ -232,7 +232,13 @@ private struct ProviderConfigSection: View {
     var onChange: () -> Void
 
     private var needsAPIKey: Bool {
-        provider != "Custom" && provider != "Apple"
+        provider != "Apple"
+    }
+
+    /// Custom (OpenAI-compatible) servers may run locally without auth, so the
+    /// key is optional there; hosted providers require it.
+    private var apiKeyIsOptional: Bool {
+        provider == "Custom"
     }
 
     private var needsModel: Bool {
@@ -275,7 +281,7 @@ private struct ProviderConfigSection: View {
                 SettingsFormRow(label: "API Key") {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(spacing: 4) {
-                            SecureField("Enter API key", text: $apiKey)
+                            SecureField(apiKeyIsOptional ? "API key (optional)" : "Enter API key", text: $apiKey)
                                 .textFieldStyle(RoundedBorderTextFieldStyle())
                                 .onChange(of: apiKey) { _ in
                                     onChange()


### PR DESCRIPTION
## Summary

Fixes #70 — TRex cannot talk to LM Studio (or other OpenAI-compatible servers) configured as a "Custom" provider.

The Settings UI advertises **Custom** as an *"OpenAI-compatible endpoint (Ollama, LM Studio, etc.)"* with a `http://localhost:11434/v1` placeholder, but the backend mapped `.custom` to `OllamaLanguageModel`, which hardcodes Ollama's **native** `/api/chat` path. As a result, pointing TRex at LM Studio produced:

```
Unexpected endpoint or method. (POST /api/v1/chat/api/chat)
```

`/api/chat` was being appended to whatever URL the user entered, and there was no path the user could type that would work — LM Studio speaks the OpenAI dialect, the backend spoke Ollama's.

## Changes

- **`UnifiedLanguageModelProvider`** — `.custom` now uses `OpenAILanguageModel`, which targets the OpenAI-compatible `/chat/completions` path. This works with LM Studio, vLLM, llama.cpp's server, OpenRouter, and Ollama's own `/v1` OpenAI bridge.
  - Forwards an optional API key (local servers ignore it; hosted ones require it).
  - Parses the endpoint safely and throws `LLMError.invalidEndpoint` instead of force-unwrapping `URL(string:)`.
  - Defaults to `http://localhost:11434/v1` when no endpoint is set.
- **`LLMSettingsView`** — adds an optional **API Key** field to the Custom provider (placeholder reads "API key (optional)").
- **Tests** — added coverage for custom-provider initialization (with/without endpoint, with API key) and malformed-endpoint rejection.

## Behavior change / migration note

This aligns the implementation with the UI's stated contract. Existing users who configured **Custom** for **Ollama** using a bare host (e.g. `http://localhost:11434`, relying on the native `/api/chat`) must append `/v1` to use Ollama's OpenAI-compatible endpoint — which is what the UI placeholder already shows.

## Testing

- `swift test` in `Packages/TRexLLM`: **33 tests, 8 skipped** (require API keys), 0 failures.
- `xcodebuild -scheme TRex -configuration Debug build`: **BUILD SUCCEEDED**.

Manual verification against a live LM Studio instance is still worthwhile before release, since the package tests exercise initialization but not a real request.