### PR TITLE
fix: ship universal (arm64 + x86_64) binaries for Intel Macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,11 +211,15 @@ jobs:
           key: trex-cli-${{ github.run_id }}-${{ github.run_attempt }}
 
   # Validates Intel support (#69) by exercising the build on a real Intel runner.
-  # macos-13 is x86_64; macos-14+ are Apple Silicon.
+  # macos-15-intel is GitHub's last Intel (x86_64) image; the other macos-*
+  # images are Apple Silicon. (macos-13, the previous Intel image, was retired
+  # in December 2025.) The timeout fails fast if the Intel label stops being
+  # schedulable rather than hanging for the 6-hour default.
   intel-smoke-test:
     name: Intel (x86_64) Smoke Test
     needs: build
-    runs-on: macos-13
+    runs-on: macos-15-intel
+    timeout-minutes: 20
     steps:
       - name: Confirm runner is Intel
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,96 @@ jobs:
           path: .cli-cache
           key: trex-cli-${{ github.run_id }}-${{ github.run_attempt }}
 
+  # Validates Intel support (#69) by exercising the build on a real Intel runner.
+  # macos-13 is x86_64; macos-14+ are Apple Silicon.
+  intel-smoke-test:
+    name: Intel (x86_64) Smoke Test
+    needs: build
+    runs-on: macos-13
+    steps:
+      - name: Confirm runner is Intel
+        run: |
+          ARCH=$(uname -m)
+          echo "Runner architecture: $ARCH"
+          if [ "$ARCH" != "x86_64" ]; then
+            echo "❌ Expected an Intel (x86_64) runner but got '$ARCH'."
+            echo "This job must run on Intel to validate Intel support (see #69)."
+            exit 1
+          fi
+
+      - name: Download Unsigned App
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-Unsigned
+          path: .
+
+      - name: Restore CLI Binary from Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cli-cache
+          key: trex-cli-${{ github.run_id }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
+
+      - name: Unpack App Bundle
+        run: ditto -x -k "${{ env.APP_NAME }}.app.zip" .
+
+      - name: Verify every embedded binary includes x86_64
+        run: |
+          APP="${{ env.APP_NAME }}.app"
+          FAIL=0
+          while IFS= read -r f; do
+            if file "$f" | grep -q "Mach-O"; then
+              ARCHS=$(lipo -archs "$f")
+              printf '%-60s %s\n' "${f#$APP/}" "$ARCHS"
+              echo "$ARCHS" | grep -qw x86_64 || { echo "   ^^^ missing x86_64"; FAIL=1; }
+            fi
+          done < <(find "$APP" -type f \( -perm +111 -o -name "*.dylib" -o -name "*.framework" \) | sort)
+          if [ "$FAIL" != 0 ]; then
+            echo "❌ One or more embedded binaries lack an x86_64 slice (would crash on Intel)"
+            exit 1
+          fi
+          echo "✅ All embedded binaries include an x86_64 slice"
+
+      - name: Launch app on Intel
+        run: |
+          APP_BIN="${{ env.APP_NAME }}.app/Contents/MacOS/${{ env.APP_NAME }}"
+          "$APP_BIN" > app_launch.log 2>&1 &
+          APP_PID=$!
+          sleep 8
+          if kill -0 "$APP_PID" 2>/dev/null; then
+            echo "✅ App launched and is running natively on Intel"
+            kill "$APP_PID" 2>/dev/null || true
+            wait "$APP_PID" 2>/dev/null || true
+          else
+            wait "$APP_PID" 2>/dev/null; CODE=$?
+            echo "App process exited early (code $CODE). Output:"
+            cat app_launch.log || true
+            # A missing x86_64 slice makes the kernel reject the binary outright;
+            # that is the exact #69 failure and must fail the job. Other early
+            # exits (e.g. headless GUI quirks) are reported but not treated as
+            # an architecture failure.
+            if grep -qi "bad CPU type" app_launch.log; then
+              echo "❌ Kernel rejected the binary on Intel — x86_64 slice missing"
+              exit 1
+            fi
+            echo "⚠️ App did not stay running, but not due to a missing arch slice."
+          fi
+
+      - name: Run CLI on Intel
+        run: |
+          CLI=".cli-cache/trex"
+          chmod +x "$CLI"
+          echo "CLI architectures: $(lipo -archs "$CLI")"
+          # The runner is Intel, so a successful run proves the x86_64 slice
+          # executes natively (and that the bundled Tesseract/Leptonica x86_64
+          # native code loads).
+          if "$CLI" --help; then
+            echo "✅ CLI ran natively on Intel"
+          else
+            echo "❌ CLI failed to run on Intel"
+            exit 1
+          fi
+
   sign:
     needs: build
     runs-on: macos-latest
@@ -371,7 +461,7 @@ jobs:
           key: trex-cli-notarized-${{ github.run_id }}-${{ github.run_attempt }}
 
   release:
-    needs: [notarize, verify-release-notes]
+    needs: [notarize, verify-release-notes, intel-smoke-test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,11 +100,14 @@ jobs:
           MARKETING_VERSION: ${{ steps.get_versions.outputs.VERSION }}
           CURRENT_PROJECT_VERSION: ${{ steps.get_versions.outputs.BUILD_NUMBER }}
         run: |
+          # Build universal (arm64 + x86_64) so the app launches on Intel Macs.
+          # TesseractSwift now ships universal xcframeworks, lifting the prior
+          # arm64-only constraint.
           xcodebuild \
             -scheme "${{ env.APP_NAME }}" \
             -configuration Release \
             -derivedDataPath build \
-            -arch arm64 \
+            -arch arm64 -arch x86_64 \
             -skipMacroValidation \
             -skipPackagePluginValidation \
             ONLY_ACTIVE_ARCH=NO \
@@ -117,13 +120,13 @@ jobs:
           MARKETING_VERSION: ${{ steps.get_versions.outputs.VERSION }}
           CURRENT_PROJECT_VERSION: ${{ steps.get_versions.outputs.BUILD_NUMBER }}
         run: |
-          # Build CLI as arm64-only due to TesseractSwift dependency lacking x86_64 support
-          # Intel Macs can run arm64 CLI via Rosetta 2
+          # Build universal (arm64 + x86_64). TesseractSwift now ships universal
+          # xcframeworks, so the CLI no longer needs to be arm64-only.
           xcodebuild \
             -scheme "TRex CLI" \
             -configuration Release \
             -derivedDataPath build-cli \
-            -arch arm64 \
+            -arch arm64 -arch x86_64 \
             -skipMacroValidation \
             -skipPackagePluginValidation \
             ONLY_ACTIVE_ARCH=NO \
@@ -138,12 +141,14 @@ jobs:
           ARCHS=$(lipo -archs "$APP_BINARY")
           echo "Found architectures: $ARCHS"
 
-          # Verify arm64 is present
-          if ! echo "$ARCHS" | grep -q "arm64"; then
-            echo "❌ Error: arm64 architecture missing from app binary"
-            exit 1
-          fi
-          echo "✅ App binary built successfully"
+          # The app must be universal so it launches on both Apple Silicon and Intel.
+          for arch in arm64 x86_64; do
+            if ! echo "$ARCHS" | grep -qw "$arch"; then
+              echo "❌ Error: $arch architecture missing from app binary"
+              exit 1
+            fi
+          done
+          echo "✅ App binary is universal (arm64 + x86_64)"
           file "$APP_BINARY"
 
       - name: Prepare CLI Binary
@@ -177,13 +182,15 @@ jobs:
           ARCHS=$(lipo -archs "$CACHE_CLI_PATH")
           echo "Found architectures: $ARCHS"
 
-          # Verify arm64 is present (CLI is arm64-only due to TesseractSwift)
-          if ! echo "$ARCHS" | grep -q "arm64"; then
-            echo "❌ Error: arm64 architecture missing from CLI binary"
-            exit 1
-          fi
+          # The CLI must be universal so it runs natively on Apple Silicon and Intel.
+          for arch in arm64 x86_64; do
+            if ! echo "$ARCHS" | grep -qw "$arch"; then
+              echo "❌ Error: $arch architecture missing from CLI binary"
+              exit 1
+            fi
+          done
 
-          echo "✅ CLI binary is arm64 (Intel Macs can run via Rosetta 2)"
+          echo "✅ CLI binary is universal (arm64 + x86_64)"
 
       - name: Package App Bundle
         run: |


### PR DESCRIPTION
## Summary

Fixes #69 — TRex 2.0 won't launch on Intel Macs (*"TRex is not supported by this Mac"*), and the Homebrew cask ships an ARM-only binary.

**Root cause:** TRex 2.0 links `TesseractSwift`, whose bundled `TesseractCore.xcframework` and `Leptonica.xcframework` were arm64-only. Linking an arm64-only library forces the entire app to arm64, and the release workflow built with `-arch arm64` — so the GitHub release artifact (and therefore the Homebrew cask) was arm64-only. Intel Macs can't run it at all.

**What changed upstream:** `TesseractSwift` v1.2.0 (the exact revision TRex pins, `404092e` / tag `v1.2.0`) now ships **universal** `macos-arm64_x86_64` xcframeworks. That removes the constraint that forced arm64-only builds.

## Changes (`.github/workflows/release.yml`)

- **App build:** `-arch arm64` → `-arch arm64 -arch x86_64` (universal).
- **CLI build:** same — and removed the now-obsolete "arm64-only due to TesseractSwift" comment. (Universal is better than the previous arm64 + Rosetta-on-Intel.)
- **Verify steps (app + CLI):** now require **both** `arm64` and `x86_64`, so an arm64-only regression can't silently ship again. (Previously they only checked for `arm64`.)

## Verification (local, on Apple Silicon)

Built both targets with the exact universal invocation the workflow now uses:

- `TRex.app/Contents/MacOS/TRex` → `x86_64 arm64`
- Every embedded Mach-O is universal:
  - `TesseractCore.framework` → `x86_64 arm64`
  - `Leptonica.framework` → `x86_64 arm64`
  - all `Sparkle.framework` components → `x86_64 arm64`
- CLI `trex` binary → `x86_64 arm64`

This matters because a single arm64-only embedded library would let the app launch but crash on Intel — all of them are confirmed universal.

## What still needs a real Intel check

I can confirm the slices exist, but an Apple Silicon machine can't *execute* the x86_64 slice of a Mac app. True runtime verification needs either a real Intel Mac or a CI smoke test on a `macos-13` (Intel) runner that launches the built app/CLI and asserts it doesn't fail with "Bad CPU type". Happy to add that CI job as a follow-up if you want it.

The fix takes effect on the **next release** (CI-only change; existing published artifacts are unaffected).