### PR TITLE
Fix watch mode appending unrelated clipboard text

### DIFF
--- a/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
@@ -276,6 +276,9 @@ public class TRex: NSObject {
     }
 
     private func captureSingle(_ mode: InvocationMode, imagePath: String? = nil) async {
+        guard beginCaptureTransaction() else { return }
+        defer { endCaptureTransaction() }
+
         currentInvocationMode = mode
 
         guard let ocrResult = await getText(imagePath) else { return }
@@ -301,15 +304,12 @@ public class TRex: NSObject {
     private static let maxMultiRegionCaptures = 50
 
     private func captureMultiRegion(_ mode: InvocationMode) async {
-        currentInvocationMode = mode
         var allTexts: [String] = []
 
-        guard !isCaptureInProgress else {
-            logger.warning("⚠️ Capture already in progress, returning early")
-            return
-        }
-        isCaptureInProgress = true
-        defer { isCaptureInProgress = false }
+        guard beginCaptureTransaction() else { return }
+        defer { endCaptureTransaction() }
+
+        currentInvocationMode = mode
 
         while allTexts.count < Self.maxMultiRegionCaptures {
             guard let nsImage = await captureScreenInteractively() else {
@@ -436,13 +436,6 @@ public class TRex: NSObject {
         logger.info("🚀 getText called - starting OCR process")
         logger.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
-        guard !isCaptureInProgress else {
-            logger.warning("⚠️ Capture already in progress, returning early")
-            return nil
-        }
-        isCaptureInProgress = true
-        defer { isCaptureInProgress = false }
-
         guard let nsImage = await getImage(imagePath) else {
             logger.error("❌ Failed to get image")
             return nil
@@ -454,6 +447,21 @@ public class TRex: NSObject {
         }
 
         return await recognizeImage(cgImage)
+    }
+
+    @discardableResult
+    func beginCaptureTransaction() -> Bool {
+        guard !isCaptureInProgress else {
+            logger.warning("⚠️ Capture already in progress, returning early")
+            return false
+        }
+
+        isCaptureInProgress = true
+        return true
+    }
+
+    func endCaptureTransaction() {
+        isCaptureInProgress = false
     }
 
     /// Run OCR on a CGImage for watch mode. Delegates to the standard recognition pipeline

--- a/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
@@ -165,6 +165,9 @@ public final class WatchModeManager: ObservableObject {
     }
 
     private func pollTick() async {
+        guard TRex.shared.beginCaptureTransaction() else { return }
+        defer { TRex.shared.endCaptureTransaction() }
+
         guard let rect = currentRect else { return }
 
         guard let image = await captureRect(rect) else {

--- a/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
@@ -28,6 +28,7 @@ public final class WatchModeManager: ObservableObject {
     private var lastImageHash: Data?
     private var pollTask: Task<Void, Never>?
     private var isPaused = false
+    private var clipboardAccumulator = ""
 
     private let preferences = Preferences.shared
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.ameba.TRex", category: "WatchMode")
@@ -74,6 +75,7 @@ public final class WatchModeManager: ObservableObject {
         preferences.watchModePollingInterval = pollingInterval
 
         lastImageHash = nil
+        resetClipboardAccumulator()
         captureCount = 0
         isPaused = false
         isCapturing = true
@@ -284,15 +286,20 @@ public final class WatchModeManager: ObservableObject {
 
     private func appendToClipboard(_ text: String) {
         let pasteboard = NSPasteboard.general
-        let existing = pasteboard.string(forType: .string) ?? ""
         let combined: String
-        if existing.isEmpty {
+        if clipboardAccumulator.isEmpty {
             combined = text
         } else {
-            combined = existing + "\n---\n" + text
+            combined = clipboardAccumulator + "\n---\n" + text
         }
         pasteboard.clearContents()
-        pasteboard.setString(combined, forType: .string)
+        if pasteboard.setString(combined, forType: .string) {
+            clipboardAccumulator = combined
+        }
+    }
+
+    private func resetClipboardAccumulator() {
+        clipboardAccumulator = ""
     }
 
     /// Resolve and validate the output file path.


### PR DESCRIPTION
Hi, first of all, thank you for building and maintaining TRex. I use it a lot, and I appreciate the work behind it.

## What this fixes

Watch mode could append a new OCR result to whatever text was already on the clipboard.

That only worked correctly when the clipboard already contained output from the same watch session. If the clipboard contained anything else, watch mode could accidentally mix unrelated text into its output.

This could happen in a few common flows:

- Starting watch mode while the clipboard already had unrelated text.
- Copying something manually while watch mode was running.
- Running a normal TRex capture while watch mode was also active.
- Stopping watch mode, then starting a new watch session while the previous watch result was still on the clipboard.

In those cases, watch mode could produce mixed output like:

```text
some unrelated clipboard text
---
new watched text
```

After this change, watch mode only appends text produced by the current watch session.

## Changes made

- Added a watch-session-owned clipboard accumulator.
- Reset the accumulator whenever a new watch session starts.
- Changed watch mode so it no longer uses arbitrary clipboard contents as append history.
- Made normal captures and watch-mode captures share the same capture transaction guard, so their OCR/output flows do not race each other.

## Tests run

I manually checked the affected watch-mode flows:

- Starting watch mode with old clipboard text now produces only the watched text.
- Manual copies made during watch mode are not included in later watch output.
- Normal TRex captures no longer get merged with watch-mode output.
- A new watch session no longer appends to output from a previous watch session.

## Extra note

While testing this, I noticed that watch mode seems to react to visual changes in the watched area, not only text changes.

For example, a blinking cursor, hover state, focus change, or small animation may cause watch mode to copy the same recognized text again.

I am not sure this is a bug, since the watched pixels did change. If this should be handled later, I think it would be better as an optional setting like “ignore repeated OCR text” rather than always removing duplicate OCR output.
