### PR TITLE
fix: send images to LLM OCR providers

### DIFF
--- a/Packages/TRexCore/Package.resolved
+++ b/Packages/TRexCore/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f6072e2d5fa0bb86369258ff0dc0163854e50548e73fa993cc3b47c81668fcf5",
+  "originHash" : "ca0abfe9779d8511b9a470a4f15b72d9ec29b7d44edf690d10c527b2668d8207",
   "pins" : [
     {
       "identity" : "anylanguagemodel",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/AnyLanguageModel.git",
+      "location" : "https://github.com/huggingface/AnyLanguageModel.git",
       "state" : {
-        "revision" : "bfee8f6198996d3094d1db521f6ab7b7965c5a54",
-        "version" : "0.3.3"
+        "revision" : "f22b78e6b10f67e7d46c67dc59a8a35bc259fbce",
+        "version" : "0.9.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "06beff60e3b609a485290e4d5d2d1e2eedb1e55d",
-        "version" : "2.7.3"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/Packages/TRexLLM/Package.resolved
+++ b/Packages/TRexLLM/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1ab93f3778cef10af16415c3ec67c03a65a6dc9ae6915eaee39c5e8fcbaf88d6",
+  "originHash" : "3d34faee26cad2a1b0bb5c27b2ae5f2de8a9926bee5328263c4ff2a75a6de078",
   "pins" : [
     {
       "identity" : "anylanguagemodel",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/AnyLanguageModel.git",
+      "location" : "https://github.com/huggingface/AnyLanguageModel.git",
       "state" : {
-        "revision" : "18b1e1b4755143767e5c8f0066b59f009f601232",
-        "version" : "0.4.0"
+        "revision" : "f22b78e6b10f67e7d46c67dc59a8a35bc259fbce",
+        "version" : "0.9.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     }
   ],

--- a/Packages/TRexLLM/Package.swift
+++ b/Packages/TRexLLM/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/mattt/AnyLanguageModel.git", from: "0.3.0")
+        .package(url: "https://github.com/huggingface/AnyLanguageModel.git", from: "0.8.0")
     ],
     targets: [
         .target(
@@ -24,7 +24,10 @@ let package = Package(
         ),
         .testTarget(
             name: "TRexLLMTests",
-            dependencies: ["TRexLLM"]
+            dependencies: [
+                "TRexLLM",
+                .product(name: "AnyLanguageModel", package: "AnyLanguageModel"),
+            ]
         ),
     ]
 )

--- a/Packages/TRexLLM/Sources/TRexLLM/Providers/UnifiedLanguageModelProvider.swift
+++ b/Packages/TRexLLM/Sources/TRexLLM/Providers/UnifiedLanguageModelProvider.swift
@@ -4,6 +4,12 @@ import AnyLanguageModel
 
 /// Unified provider using AnyLanguageModel for all backends
 public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendable {
+    struct PreparedOCRRequest {
+        let prompt: String
+        let imageData: Data
+        let mimeType: String
+    }
+
     public var name: String
     public var supportedModels: [String]
 
@@ -87,16 +93,46 @@ public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendabl
         self.session = LanguageModelSession(model: model)
     }
 
-    /// Perform OCR using vision-capable LLM
-    ///
-    /// AnyLanguageModel does not currently expose a vision/image API.
-    /// LLM-based OCR is handled by LLMOCREngine which makes direct provider API calls.
+    init(model: any LanguageModel) {
+        self.name = "Test"
+        self.supportedModels = []
+        self.model = model
+        self.session = LanguageModelSession(model: model)
+    }
+
+    /// Perform OCR using a vision-capable LLM.
     public func performOCR(
         image: NSImage,
         prompt: String?,
         model: String
     ) async throws -> String {
-        throw LLMError.unsupportedOperation("Vision OCR is not supported through AnyLanguageModel. Use LLMOCREngine for direct API-based vision OCR.")
+        let request = try Self.prepareOCRRequest(image: image, prompt: prompt)
+        let imageSegment = Transcript.ImageSegment(
+            data: request.imageData,
+            mimeType: request.mimeType
+        )
+        let ocrSession = LanguageModelSession(model: self.model)
+        let response = try await ocrSession.respond(
+            to: request.prompt,
+            image: imageSegment
+        )
+        return response.content
+    }
+
+    static func prepareOCRRequest(image: NSImage, prompt: String?) throws -> PreparedOCRRequest {
+        let trimmedPrompt = prompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedPrompt: String
+        if let trimmedPrompt, !trimmedPrompt.isEmpty {
+            resolvedPrompt = trimmedPrompt
+        } else {
+            resolvedPrompt = PromptTemplates.defaultOCRPrompt
+        }
+
+        return PreparedOCRRequest(
+            prompt: resolvedPrompt,
+            imageData: try ImagePreprocessor().preprocess(image),
+            mimeType: "image/jpeg"
+        )
     }
 
     /// Process text with LLM

--- a/Packages/TRexLLM/Tests/TRexLLMTests/LLMProviderIntegrationTests.swift
+++ b/Packages/TRexLLM/Tests/TRexLLMTests/LLMProviderIntegrationTests.swift
@@ -49,6 +49,29 @@ final class LLMProviderIntegrationTests: XCTestCase {
         return image
     }
 
+    private func createVerticalJapaneseTestImage(_ text: String) -> NSImage {
+        let size = NSSize(width: 160, height: 320)
+        let image = NSImage(size: size)
+        image.lockFocus()
+
+        NSColor.white.setFill()
+        NSRect(origin: .zero, size: size).fill()
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 36),
+            .foregroundColor: NSColor.black,
+        ]
+        for (index, character) in text.enumerated() {
+            String(character).draw(
+                at: NSPoint(x: 60, y: 250 - CGFloat(index * 55)),
+                withAttributes: attributes
+            )
+        }
+
+        image.unlockFocus()
+        return image
+    }
+
     // MARK: - Provider Initialization
 
     func testOpenAIProviderInitialization() throws {
@@ -231,7 +254,8 @@ final class LLMProviderIntegrationTests: XCTestCase {
             modelName: "gpt-4.1-mini"
         )
 
-        let testImage = createTestImageWithText("Hello TRex")
+        let expectedText = "縦書き"
+        let testImage = createVerticalJapaneseTestImage(expectedText)
 
         let result = try await provider.performOCR(
             image: testImage,
@@ -240,10 +264,9 @@ final class LLMProviderIntegrationTests: XCTestCase {
         )
 
         XCTAssertFalse(result.isEmpty, "OCR result should not be empty")
-        let lowered = result.lowercased()
         XCTAssertTrue(
-            lowered.contains("hello") || lowered.contains("trex"),
-            "OCR should recognize text from image, got: \(result)"
+            result.contains("縦") || result.contains("書") || result.contains("き"),
+            "OCR should recognize vertical Japanese text, got: \(result)"
         )
     }
 
@@ -259,7 +282,8 @@ final class LLMProviderIntegrationTests: XCTestCase {
             modelName: "claude-sonnet-4-5-20250929"
         )
 
-        let testImage = createTestImageWithText("Hello TRex")
+        let expectedText = "縦書き"
+        let testImage = createVerticalJapaneseTestImage(expectedText)
 
         let result = try await provider.performOCR(
             image: testImage,
@@ -268,10 +292,9 @@ final class LLMProviderIntegrationTests: XCTestCase {
         )
 
         XCTAssertFalse(result.isEmpty, "OCR result should not be empty")
-        let lowered = result.lowercased()
         XCTAssertTrue(
-            lowered.contains("hello") || lowered.contains("trex"),
-            "OCR should recognize text from image, got: \(result)"
+            result.contains("縦") || result.contains("書") || result.contains("き"),
+            "OCR should recognize vertical Japanese text, got: \(result)"
         )
     }
 

--- a/Packages/TRexLLM/Tests/TRexLLMTests/UnifiedLanguageModelProviderTests.swift
+++ b/Packages/TRexLLM/Tests/TRexLLMTests/UnifiedLanguageModelProviderTests.swift
@@ -1,0 +1,110 @@
+import AppKit
+import AnyLanguageModel
+import XCTest
+
+@testable import TRexLLM
+
+final class UnifiedLanguageModelProviderTests: XCTestCase {
+    func testPrepareOCRRequestUsesDefaultPromptAndJPEG() throws {
+        let request = try UnifiedLanguageModelProvider.prepareOCRRequest(
+            image: makeTestImage(),
+            prompt: nil
+        )
+
+        XCTAssertEqual(request.prompt, PromptTemplates.defaultOCRPrompt)
+        XCTAssertEqual(request.mimeType, "image/jpeg")
+        XCTAssertEqual(Array(request.imageData.prefix(3)), [0xFF, 0xD8, 0xFF])
+    }
+
+    func testPrepareOCRRequestUsesCustomPrompt() throws {
+        let request = try UnifiedLanguageModelProvider.prepareOCRRequest(
+            image: makeTestImage(),
+            prompt: "  Read the vertical Japanese text.  "
+        )
+
+        XCTAssertEqual(request.prompt, "Read the vertical Japanese text.")
+    }
+
+    func testPrepareOCRRequestUsesDefaultForBlankPrompt() throws {
+        let request = try UnifiedLanguageModelProvider.prepareOCRRequest(
+            image: makeTestImage(),
+            prompt: " \n "
+        )
+
+        XCTAssertEqual(request.prompt, PromptTemplates.defaultOCRPrompt)
+    }
+
+    func testPerformOCRUsesFreshSessionForEachCapture() async throws {
+        let recorder = TranscriptRecorder()
+        let provider = UnifiedLanguageModelProvider(model: RecordingLanguageModel(recorder: recorder))
+
+        _ = try await provider.performOCR(image: makeTestImage(), prompt: nil, model: "test")
+        _ = try await provider.performOCR(image: makeTestImage(), prompt: nil, model: "test")
+
+        let summaries = await recorder.summaries
+        XCTAssertEqual(summaries.map(\.entryCount), [1, 1])
+        XCTAssertEqual(summaries.map(\.imageCount), [1, 1])
+    }
+
+    private func makeTestImage() -> NSImage {
+        let size = NSSize(width: 120, height: 80)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.white.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        image.unlockFocus()
+        return image
+    }
+}
+
+private actor TranscriptRecorder {
+    struct Summary: Sendable {
+        let entryCount: Int
+        let imageCount: Int
+    }
+
+    private(set) var summaries: [Summary] = []
+
+    func record(_ transcript: Transcript) {
+        let imageCount = transcript.reduce(into: 0) { count, entry in
+            guard case .prompt(let prompt) = entry else { return }
+            count += prompt.segments.filter {
+                if case .image = $0 { return true }
+                return false
+            }.count
+        }
+        summaries.append(Summary(entryCount: transcript.count, imageCount: imageCount))
+    }
+}
+
+private struct RecordingLanguageModel: LanguageModel {
+    typealias UnavailableReason = Never
+
+    let recorder: TranscriptRecorder
+
+    func respond<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) async throws -> LanguageModelSession.Response<Content> where Content: Generable {
+        await recorder.record(session.transcript)
+        let content = "recognized text"
+        return LanguageModelSession.Response(
+            content: content as! Content,
+            rawContent: GeneratedContent(content),
+            transcriptEntries: []
+        )
+    }
+
+    func streamResponse<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) -> sending LanguageModelSession.ResponseStream<Content> where Content: Generable {
+        fatalError("Streaming is not used by OCR tests")
+    }
+}


### PR DESCRIPTION
## Summary

- upgrade AnyLanguageModel to a multimodal-capable release
- send preprocessed JPEG captures to OpenAI-compatible and Anthropic OCR providers
- isolate each OCR capture in a fresh session and cover vertical Japanese text

## Validation

- `swift test --package-path Packages/TRexLLM`
- `swift test --package-path Packages/TRexCore`
- `xcodebuild -project TRex.xcodeproj -scheme TRex -configuration Debug -derivedDataPath /tmp/trex-llm-vision-derived -skipMacroValidation -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build`

Closes #72