### PR TITLE
fix: harden beta updates and project reliability

### DIFF
--- a/.github/actions/notarize/action.yaml
+++ b/.github/actions/notarize/action.yaml
@@ -24,11 +24,6 @@ runs:
         echo "This action only works on macOS."
         exit 1
 
-    - name: Install dependencies
-      shell: bash
-      run: |
-        brew install zip
-
     - name: Create temporary directory
       id: tmp
       shell: bash
@@ -55,8 +50,9 @@ runs:
           --output-format json \
           | tee "${{ steps.tmp.outputs.path }}/notarization_output.json"
 
-        if ! grep -q "Accepted" "${{ steps.tmp.outputs.path }}/notarization_output.json"; then
-          echo "Notarization failed"
+        STATUS=$(jq -r '.status // empty' "${{ steps.tmp.outputs.path }}/notarization_output.json")
+        if [ "$STATUS" != "Accepted" ]; then
+          echo "Notarization failed with status: ${STATUS:-unknown}"
           exit 1
         fi
 
@@ -65,3 +61,8 @@ runs:
       run: |
         xcrun stapler staple "${{ inputs.app-path }}"
         xcrun stapler validate "${{ inputs.app-path }}"
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -rf "${{ steps.tmp.outputs.path }}"

--- a/.github/actions/sparkle-sign/action.yaml
+++ b/.github/actions/sparkle-sign/action.yaml
@@ -57,8 +57,10 @@ runs:
           exit 1
         fi
 
-        # Create temporary directory for keys
-        KEYS_DIR=$(mktemp -d)
+        # Keep key material under the action temp directory so the always-run
+        # cleanup step removes it even when decoding or signing fails.
+        KEYS_DIR="$TEMP_DIR/keys"
+        mkdir -p "$KEYS_DIR"
         echo "Created temp dir for keys: $KEYS_DIR"
 
         # Decode private key with error checking
@@ -94,9 +96,6 @@ runs:
           echo "Error: Empty signature generated"
           exit 1
         fi
-
-        # Clean up
-        rm -rf "$KEYS_DIR"
 
         # Set output
         echo "signature=$SIGNATURE" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Build and Release
 on:
   push:
-    branches-ignore:
-      - main
     tags:
       - "v*.*.*"
       - "v*.*.*-beta.*"
@@ -75,11 +73,12 @@ jobs:
             exit 1
           fi
 
+          # Sparkle orders releases by build number. A semantically newer beta
+          # with an older build number is still invisible to users who already
+          # installed the production build.
           if [ "$BETA_BUILD" -lt "$PROD_BUILD" ]; then
-            if ! ruby -rrubygems -e 'exit Gem::Version.new(ARGV[0]) > Gem::Version.new(ARGV[1]) ? 0 : 1' "$BETA_VERSION" "$PROD_VERSION"; then
-              echo "Error: Beta feed ${BETA_VERSION} (${BETA_BUILD}) is behind production ${PROD_VERSION} (${PROD_BUILD})"
-              exit 1
-            fi
+            echo "Error: Beta feed ${BETA_VERSION} (${BETA_BUILD}) is behind production ${PROD_VERSION} (${PROD_BUILD})"
+            exit 1
           fi
 
       - name: Get Version Numbers
@@ -376,6 +375,7 @@ jobs:
 
   sign:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -436,6 +436,7 @@ jobs:
 
   notarize:
     needs: sign
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/Packages/TRexCore/Sources/TRexCore/CaptureHistoryStore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/CaptureHistoryStore.swift
@@ -60,6 +60,7 @@ public final class CaptureHistoryStore: ObservableObject {
 
     /// Add a new history entry from captured text and an optional OCR result.
     public func addEntry(text: String, ocrResult: OCRResult? = nil, maxEntries: Int = 100) {
+        let maxEntries = max(1, maxEntries)
         let entryID = UUID()
         var thumbnailFilename: String?
 

--- a/Packages/TRexCore/Sources/TRexCore/LanguageCodeMapper.swift
+++ b/Packages/TRexCore/Sources/TRexCore/LanguageCodeMapper.swift
@@ -8,26 +8,17 @@ public enum LanguageCodeMapper {
         let normalized = identifier.replacingOccurrences(of: "_", with: "-")
 
         // Parse components
-        var components = Locale.components(fromIdentifier: normalized)
-        if let language = components[NSLocale.Key.languageCode.rawValue] {
-            components[NSLocale.Key.languageCode.rawValue] = language.lowercased()
-        }
-        if let script = components[NSLocale.Key.scriptCode.rawValue] {
-            components[NSLocale.Key.scriptCode.rawValue] = script.capitalized
-        }
-        if let region = components[NSLocale.Key.countryCode.rawValue] {
-            components[NSLocale.Key.countryCode.rawValue] = region.uppercased()
-        }
+        let components = Locale.Components(identifier: normalized)
 
         // Build the identifier manually to ensure hyphen format
         var parts: [String] = []
-        if let language = components[NSLocale.Key.languageCode.rawValue] {
+        if let language = components.languageComponents.languageCode?.identifier {
             parts.append(language.lowercased())
         }
-        if let script = components[NSLocale.Key.scriptCode.rawValue] {
+        if let script = components.languageComponents.script?.identifier {
             parts.append(script.capitalized)
         }
-        if let region = components[NSLocale.Key.countryCode.rawValue] {
+        if let region = components.languageComponents.region?.identifier {
             parts.append(region.uppercased())
         }
 

--- a/Packages/TRexCore/Sources/TRexCore/LanguageManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/LanguageManager.swift
@@ -269,8 +269,8 @@ public class LanguageManager {
         }
         
         // Try base language code
-        let components = Locale.components(fromIdentifier: normalizedCode)
-        if let languageCode = components[NSLocale.Key.languageCode.rawValue], 
+        let components = Locale.Components(identifier: normalizedCode)
+        if let languageCode = components.languageComponents.languageCode?.identifier,
            let explicit = overrides[languageCode] {
             return explicit
         }
@@ -304,17 +304,7 @@ public class LanguageManager {
 
     /// Normalize codes like "cs_CZ" into "cs-CZ"
     private func normalizeIdentifier(_ code: String) -> String {
-        var components = Locale.components(fromIdentifier: code.replacingOccurrences(of: "_", with: "-"))
-        if let lang = components[NSLocale.Key.languageCode.rawValue] {
-            components[NSLocale.Key.languageCode.rawValue] = lang.lowercased()
-        }
-        if let script = components[NSLocale.Key.scriptCode.rawValue] {
-            components[NSLocale.Key.scriptCode.rawValue] = script.capitalized
-        }
-        if let region = components[NSLocale.Key.countryCode.rawValue] {
-            components[NSLocale.Key.countryCode.rawValue] = region.uppercased()
-        }
-        return Locale.identifier(fromComponents: components)
+        LanguageCodeMapper.standardize(code)
     }
     
     /// Get flag emoji for a language code

--- a/Packages/TRexCore/Sources/TRexCore/OCREngine.swift
+++ b/Packages/TRexCore/Sources/TRexCore/OCREngine.swift
@@ -111,6 +111,9 @@ public final class OCRManager: Sendable {
 
     public func registerEngine(_ engine: OCREngine) {
         _engines.withLock { engines in
+            // Configuration changes can recreate an engine. Replace the old
+            // instance instead of accumulating duplicate entries indefinitely.
+            engines.removeAll { $0.identifier == engine.identifier }
             engines.append(engine)
             engines.sort { $0.priority > $1.priority }
         }
@@ -207,97 +210,78 @@ public final class VisionOCREngine: OCREngine {
     }
     
     public func recognizeText(in image: CGImage, languages: [String], recognitionLevel: VNRequestTextRecognitionLevel) async throws -> OCRResult {
+        try await recognizeText(
+            in: image,
+            languages: languages,
+            recognitionLevel: recognitionLevel,
+            customWords: [],
+            automaticallyDetectsLanguage: languages.isEmpty
+        )
+    }
+
+    func recognizeText(
+        in image: CGImage,
+        languages: [String],
+        recognitionLevel: VNRequestTextRecognitionLevel,
+        customWords: [String],
+        automaticallyDetectsLanguage: Bool
+    ) async throws -> OCRResult {
         Self.logger.info("🔍 VisionOCREngine.recognizeText called")
         Self.logger.info("  → Languages: \(languages.joined(separator: ", "), privacy: .public)")
         let levelString = recognitionLevel == .accurate ? "accurate" : "fast"
         Self.logger.info("  → Recognition level: \(levelString, privacy: .public)")
         Self.logger.info("  → Image size: \(image.width, privacy: .public)x\(image.height, privacy: .public)")
 
-        // Enhance image contrast for better recognition
-        let enhancedImage = enhanceImageContrast(image)
-        Self.logger.debug("🎨 Image contrast enhanced")
-
         return try await withCheckedThrowingContinuation { continuation in
-            let request = VNRecognizeTextRequest { request, error in
-                if let error = error {
-                    Self.logger.error("❌ Vision request failed: \(error.localizedDescription, privacy: .public)")
-                    continuation.resume(throwing: error)
-                    return
+            // VNImageRequestHandler.perform is synchronous and can take several
+            // seconds. Keep it off the caller's executor (normally MainActor).
+            DispatchQueue.global(qos: .userInitiated).async {
+                let enhancedImage = Self.enhanceImageContrast(image)
+                Self.logger.debug("🎨 Image contrast enhanced")
+
+                let request = VNRecognizeTextRequest()
+                request.automaticallyDetectsLanguage = automaticallyDetectsLanguage
+                if !automaticallyDetectsLanguage {
+                    request.recognitionLanguages = languages
                 }
+                request.recognitionLevel = recognitionLevel
+                request.usesLanguageCorrection = true
+                request.minimumTextHeight = 0.0
+                request.customWords = customWords
 
-                guard let observations = request.results as? [VNRecognizedTextObservation] else {
-                    Self.logger.warning("⚠️ No observations returned from Vision")
-                    continuation.resume(returning: OCRResult(
-                        text: "",
-                        confidence: 0,
-                        recognizedLanguages: languages,
-                        engineName: "Apple Vision",
-                        recognitionLevel: levelString
-                    ))
-                    return
-                }
+                let handler = VNImageRequestHandler(cgImage: enhancedImage, orientation: .up)
 
-                Self.logger.info("📊 Vision returned \(observations.count, privacy: .public) text observations")
+                do {
+                    try handler.perform([request])
+                    let observations = request.results ?? []
+                    Self.logger.info("📊 Vision returned \(observations.count, privacy: .public) text observations")
 
-                var text = ""
-                var totalConfidence: Float = 0
-                var count = 0
+                    var text = ""
+                    var totalConfidence: Float = 0
+                    var count = 0
 
-                for (index, observation) in observations.enumerated() {
-                    let candidates = observation.topCandidates(3)
-                    if let topCandidate = candidates.first {
+                    for observation in observations {
+                        guard let topCandidate = observation.topCandidates(1).first else { continue }
                         if !text.isEmpty {
                             text.append("\n")
                         }
                         text.append(topCandidate.string)
                         totalConfidence += topCandidate.confidence
                         count += 1
-
-                        // Log first 5 observations with their top candidates
-                        if index < 5 {
-                            Self.logger.debug("  Line \(index, privacy: .public): '\(topCandidate.string, privacy: .public)' (confidence: \(String(format: "%.2f", topCandidate.confidence), privacy: .public))")
-                            if candidates.count > 1 {
-                                let alternates = candidates.dropFirst().map { "'\($0.string)' (\(String(format: "%.2f", $0.confidence)))" }.joined(separator: ", ")
-                                Self.logger.debug("    Alternates: \(alternates, privacy: .public)")
-                            }
-                        }
                     }
+
+                    let averageConfidence = count > 0 ? totalConfidence / Float(count) : 0
+                    continuation.resume(returning: OCRResult(
+                        text: text,
+                        confidence: averageConfidence,
+                        recognizedLanguages: languages,
+                        engineName: "Apple Vision",
+                        recognitionLevel: levelString
+                    ))
+                } catch {
+                    Self.logger.error("❌ Vision handler.perform failed: \(error.localizedDescription, privacy: .public)")
+                    continuation.resume(throwing: error)
                 }
-
-                let avgConfidence = count > 0 ? totalConfidence / Float(count) : 0
-                Self.logger.info("✅ Recognition complete: \(count, privacy: .public) lines, avg confidence: \(String(format: "%.2f", avgConfidence), privacy: .public)")
-                Self.logger.info("  → Total text length: \(text.count, privacy: .public) characters")
-
-                continuation.resume(returning: OCRResult(
-                    text: text,
-                    confidence: avgConfidence,
-                    recognizedLanguages: languages,
-                    engineName: "Apple Vision",
-                    recognitionLevel: levelString
-                ))
-            }
-
-            request.recognitionLanguages = languages
-            request.recognitionLevel = recognitionLevel
-            request.usesLanguageCorrection = true
-
-            // Improve recognition of individual characters and symbols
-            if #available(macOS 13.0, *) {
-                request.minimumTextHeight = 0.0  // Recognize even small text
-            }
-
-            Self.logger.debug("🔧 Vision request configured:")
-            Self.logger.debug("  → recognitionLanguages: \(request.recognitionLanguages.joined(separator: ", "), privacy: .public)")
-            Self.logger.debug("  → usesLanguageCorrection: \(request.usesLanguageCorrection, privacy: .public)")
-            Self.logger.debug("  → minimumTextHeight: 0.0 (recognize small text)")
-
-            let handler = VNImageRequestHandler(cgImage: enhancedImage, orientation: .up)
-
-            do {
-                try handler.perform([request])
-            } catch {
-                Self.logger.error("❌ Vision handler.perform failed: \(error.localizedDescription, privacy: .public)")
-                continuation.resume(throwing: error)
             }
         }
     }
@@ -420,7 +404,7 @@ public final class VisionOCREngine: OCREngine {
 
     // MARK: - Image Enhancement
 
-    private func enhanceImageContrast(_ image: CGImage) -> CGImage {
+    private static func enhanceImageContrast(_ image: CGImage) -> CGImage {
         let ciImage = CIImage(cgImage: image)
 
         // Apply contrast and brightness adjustments

--- a/Packages/TRexCore/Sources/TRexCore/Preferences.swift
+++ b/Packages/TRexCore/Sources/TRexCore/Preferences.swift
@@ -79,8 +79,11 @@ public class Preferences: ObservableObject {
             case .Option6:
                 image = NSImage(systemSymbolName: "text.cursor", accessibilityDescription: nil)?.withSymbolConfiguration(imageConfig)
             }
-            image?.isTemplate = true
-            return image!
+            let resolvedImage = image
+                ?? NSImage(systemSymbolName: "text.viewfinder", accessibilityDescription: "TRex")
+                ?? NSImage(size: NSSize(width: 20, height: 20))
+            resolvedImage.isTemplate = true
+            return resolvedImage
         }
     }
 
@@ -425,7 +428,12 @@ public class Preferences: ObservableObject {
         llmOCRProvider = Preferences.getValue(key: .LLMOCRProvider) as? String ?? "OpenAI"
         llmOCRAPIKey = Preferences.getValue(key: .LLMOCRAPIKey) as? String ?? ""
         llmOCRCustomEndpoint = Preferences.getValue(key: .LLMOCRCustomEndpoint) as? String ?? ""
-        llmPostProcessProvider = Preferences.getValue(key: .LLMPostProcessProvider) as? String ?? "OpenAI"
+        let storedPostProcessProvider = Preferences.getValue(key: .LLMPostProcessProvider) as? String ?? "OpenAI"
+        if storedPostProcessProvider == "Apple", #unavailable(macOS 26.0) {
+            llmPostProcessProvider = "OpenAI"
+        } else {
+            llmPostProcessProvider = storedPostProcessProvider
+        }
         llmPostProcessAPIKey = Preferences.getValue(key: .LLMPostProcessAPIKey) as? String ?? ""
         llmPostProcessCustomEndpoint = Preferences.getValue(key: .LLMPostProcessCustomEndpoint) as? String ?? ""
         llmOCRModel = Preferences.getValue(key: .LLMOCRModel) as? String ?? "gpt-4.1-mini"

--- a/Packages/TRexCore/Sources/TRexCore/RegionSelectionOverlay.swift
+++ b/Packages/TRexCore/Sources/TRexCore/RegionSelectionOverlay.swift
@@ -84,7 +84,15 @@ public final class RegionSelectionOverlay {
     }
 
     private static func screenScale(for point: CGPoint) -> CGFloat {
-        if let screen = NSScreen.screens.first(where: { $0.frame.contains(point) }) {
+        // CGEvent locations use the global display coordinate system (origin at
+        // the top-left of the main display), unlike NSScreen.frame. Compare
+        // against CGDisplayBounds so vertically arranged displays map correctly.
+        if let screen = NSScreen.screens.first(where: { screen in
+            guard let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+                return false
+            }
+            return CGDisplayBounds(displayID).contains(point)
+        }) {
             return screen.backingScaleFactor
         }
         return NSScreen.main?.backingScaleFactor ?? 2.0

--- a/Packages/TRexCore/Sources/TRexCore/ShortcutsManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/ShortcutsManager.swift
@@ -11,11 +11,7 @@ public class ShortcutsManager: ObservableObject {
         Preferences.shared.autoRunShortcut
     }
 
-    nonisolated let shortcutInputPath: URL
-
     public init() {
-        let directory = NSTemporaryDirectory()
-        self.shortcutInputPath = NSURL.fileURL(withPathComponents: [directory, "shortcutInput"])!
         if #available(macOS 12, *) {
             getShortcuts()
         }
@@ -70,31 +66,33 @@ public class ShortcutsManager: ObservableObject {
     }
 
     public func runShortcut(inputText: String) {
-        guard !currentShortcut.isEmpty else { return }
+        let shortcut = currentShortcut
+        guard !shortcut.isEmpty else { return }
         guard isShortcutsAvailable() else { return }
+        let inputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("trex-shortcut-\(UUID().uuidString).txt")
 
         Task.detached(priority: .utility) { [weak self] in
             guard let self = self else { return }
+            defer { try? FileManager.default.removeItem(at: inputURL) }
 
             do {
-                try inputText.write(toFile: self.shortcutInputPath.path, atomically: true, encoding: .utf8)
+                try inputText.write(to: inputURL, atomically: true, encoding: .utf8)
             } catch {
                 return
             }
 
             let process = Process()
             process.executableURL = self.shortcutsURL
-            process.arguments = ["run", "\(self.currentShortcut)", "-i", "\(self.shortcutInputPath.path)"]
+            process.arguments = ["run", shortcut, "-i", inputURL.path]
 
             do {
                 try process.run()
             } catch {
-                try? FileManager.default.removeItem(at: self.shortcutInputPath)
                 return
             }
 
             process.waitUntilExit()
-            try? FileManager.default.removeItem(at: self.shortcutInputPath)
         }
     }
 

--- a/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
@@ -22,19 +22,58 @@ enum TimeoutError: Error {
 
 // Async timeout utility
 func withTimeout<T: Sendable>(seconds: TimeInterval, operation: @escaping @Sendable () async throws -> T) async throws -> T {
-    try await withThrowingTaskGroup(of: T.self) { group in
-        group.addTask {
-            try await operation()
-        }
+    guard seconds.isFinite, seconds > 0 else {
+        throw TimeoutError.timedOut
+    }
 
-        group.addTask {
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-            throw TimeoutError.timedOut
-        }
+    let operationTask = Task { try await operation() }
+    let timeoutTask = Task<T, Error> {
+        try await Task.sleep(for: .seconds(seconds))
+        throw TimeoutError.timedOut
+    }
 
-        let result = try await group.next()!
-        group.cancelAll()
-        return result
+    return try await withTaskCancellationHandler {
+        try await withCheckedThrowingContinuation { continuation in
+            let race = ContinuationRace(continuation)
+
+            Task {
+                do {
+                    race.resume(with: .success(try await operationTask.value))
+                } catch {
+                    race.resume(with: .failure(error))
+                }
+                timeoutTask.cancel()
+            }
+
+            Task {
+                do {
+                    race.resume(with: .success(try await timeoutTask.value))
+                } catch {
+                    race.resume(with: .failure(error))
+                }
+                operationTask.cancel()
+            }
+        }
+    } onCancel: {
+        operationTask.cancel()
+        timeoutTask.cancel()
+    }
+}
+
+private final class ContinuationRace<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+
+    init(_ continuation: CheckedContinuation<Value, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(with result: Result<Value, Error>) {
+        lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(with: result)
     }
 }
 
@@ -203,12 +242,15 @@ public class TRex: NSObject {
     private func detectAndFormatTables(ocrText: String, capturedImage: CGImage?) async -> String? {
         let format = preferences.tableOutputFormat
 
-        if #available(macOS 26, *), let cgImage = capturedImage {
-            return await detectTablesViaVision(in: cgImage, format: format)
+        if #available(macOS 26, *),
+           let cgImage = capturedImage,
+           let visionResult = await detectTablesViaVision(in: cgImage, format: format) {
+            return visionResult
         }
 
-        // Pre-macOS 26: use LLM for table detection only if LLM OCR is enabled
-        if preferences.llmEnableOCR {
+        // Fall back to the configured post-processor when Vision is unavailable,
+        // fails, or finds no tables. This does not require LLM OCR to be enabled.
+        if llmPostProcessor != nil {
             return await detectTablesViaLLM(ocrText: ocrText, format: format)
         }
 
@@ -254,12 +296,12 @@ public class TRex: NSObject {
 
         logger.info("📊 Using LLM for table detection (Vision unavailable fallback)")
         let processingState = llmProcessingState
-        await processingState.set(true)
+        processingState.set(true)
         let prompt = Self.tableDetectionPrompt
             .replacingOccurrences(of: "{format}", with: format.rawValue)
             .replacingOccurrences(of: "{text}", with: ocrText)
         let result = await postProcessor.processSilently(ocrText, prompt: prompt)
-        await processingState.set(false)
+        processingState.set(false)
 
         // Only return if the LLM actually modified the text (i.e. found tables)
         guard result != ocrText else { return nil }
@@ -288,14 +330,14 @@ public class TRex: NSObject {
         if preferences.llmEnablePostProcessing, let postProcessor = llmPostProcessor {
             logger.info("📝 Applying LLM post-processing...")
             let processingState = llmProcessingState
-            await processingState.set(true)
+            processingState.set(true)
             let metadata = ocrResult.contextDescription()
             text = await postProcessor.processSilently(text, metadata: metadata)
-            await processingState.set(false)
+            processingState.set(false)
             logger.info("✅ Post-processing complete")
         }
 
-        await processDetectedText(text, ocrResult: ocrResult)
+        processDetectedText(text, ocrResult: ocrResult)
     }
 
     /// Capture multiple screen regions in a loop, OCR each one, and combine results.
@@ -334,13 +376,13 @@ public class TRex: NSObject {
         // Apply LLM post-processing once on the combined text
         if preferences.llmEnablePostProcessing, let postProcessor = llmPostProcessor {
             let processingState = llmProcessingState
-            await processingState.set(true)
+            processingState.set(true)
             let metadata = "Multi-region capture (\(allTexts.count) regions)"
             combined = await postProcessor.processSilently(combined, metadata: metadata)
-            await processingState.set(false)
+            processingState.set(false)
         }
 
-        await processDetectedText(combined)
+        processDetectedText(combined)
     }
 
     /// Run OCR on a CGImage and apply table detection if enabled.
@@ -523,8 +565,10 @@ public class TRex: NSObject {
             logger.info("🔤 Languages array: [\(languages.joined(separator: ", "), privacy: .public)]")
         }
 
+        let useTesseract = preferences.tesseractEnabled && !preferences.tesseractLanguages.isEmpty
+
         // If automatic detection is enabled and we're not using Tesseract, use Vision directly
-        if preferences.automaticLanguageDetection && !preferences.tesseractEnabled && ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 13 {
+        if preferences.automaticLanguageDetection && !useTesseract && ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 13 {
             logger.info("🛤️ OCR Path: Vision with AUTOMATIC language detection")
             return await performVisionOCR(cgImage: cgImage)
         }
@@ -533,14 +577,14 @@ public class TRex: NSObject {
         if preferences.llmEnabled && preferences.llmEnableOCR, let llmEngine = llmEngine {
             logger.info("🛤️ OCR Path: Using LLM OCR engine")
             let processingState = llmProcessingState
-            await processingState.set(true)
+            processingState.set(true)
             let result = await performOCR(with: llmEngine, cgImage: cgImage, languages: languages)
-            await processingState.set(false)
+            processingState.set(false)
             return result
         }
 
         // If Tesseract is disabled, only use Vision
-        if !preferences.tesseractEnabled {
+        if !useTesseract {
             logger.info("🛤️ OCR Path: Using Apple Vision (Tesseract disabled)")
             if let visionEngine = OCRManager.shared.engines.first(where: { $0.identifier == "vision" }) {
                 return await performOCR(with: visionEngine, cgImage: cgImage, languages: languages)
@@ -597,25 +641,35 @@ public class TRex: NSObject {
     }
 
     private func performVisionOCR(cgImage: CGImage) async -> OCRResult? {
-        logger.info("🔧 performVisionOCR (legacy path) called")
-        return await withCheckedContinuation { continuation in
-            detectText(in: cgImage) { text in
-                if let text = text {
-                    self.logger.info("✅ Legacy Vision OCR successful, result length: \(text.count, privacy: .public)")
-                    let result = OCRResult(
-                        text: text,
-                        confidence: 0.0, // Legacy path doesn't provide confidence
-                        recognizedLanguages: [self.preferences.recognitionLanguageCode],
-                        engineName: "Apple Vision (Legacy)",
-                        recognitionLevel: "accurate",
-                        sourceImage: cgImage
-                    )
-                    continuation.resume(returning: result)
-                } else {
-                    self.logger.warning("⚠️ Legacy Vision OCR returned no text")
-                    continuation.resume(returning: nil)
-                }
+        logger.info("🔧 performVisionOCR called")
+        let automaticallyDetectsLanguage = preferences.automaticLanguageDetection
+        let languages = automaticallyDetectsLanguage
+            ? []
+            : [LanguageCodeMapper.standardize(preferences.recognitionLanguageCode)]
+
+        do {
+            var result = try await VisionOCREngine().recognizeText(
+                in: cgImage,
+                languages: languages,
+                recognitionLevel: .accurate,
+                customWords: preferences.customWordsList,
+                automaticallyDetectsLanguage: automaticallyDetectsLanguage
+            )
+            if preferences.ignoreLineBreaks {
+                result = result.with(text: result.text.replacingOccurrences(of: "\n", with: " "))
             }
+            guard !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                logger.info("Vision OCR found no text")
+                return nil
+            }
+            result = result.with(sourceImage: cgImage)
+            if preferences.autoOpenCapturedURL {
+                detectAndOpenURL(text: result.text)
+            }
+            return result
+        } catch {
+            logger.error("Vision OCR failed: \(error.localizedDescription, privacy: .public)")
+            return nil
         }
     }
 
@@ -662,22 +716,31 @@ public class TRex: NSObject {
         return
     }
 
-    private func detectAndOpenURL(text: String) {
+    static func detectedURLs(in text: String) -> [URL] {
         let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-        let matches = detector?.matches(in: text, options: [], range: NSRange(location: 0, length: text.count))
+        let matches = detector?.matches(
+            in: text,
+            options: [],
+            range: NSRange(location: 0, length: text.utf16.count)
+        ) ?? []
 
-        matches?.forEach { match in
+        return matches.compactMap { match in
             guard let range = Range(match.range, in: text),
                   case let urlStr = String(text[range]),
                   let url = URL(string: urlStr)
-            else { return }
+            else { return nil }
             if url.scheme == nil,
                case let urlStr = "https://\(url.absoluteString)",
                let newUrl = URL(string: urlStr)
             {
-                NSWorkspace.shared.open(newUrl)
-                return
+                return newUrl
             }
+            return url
+        }
+    }
+
+    private func detectAndOpenURL(text: String) {
+        Self.detectedURLs(in: text).forEach { url in
             NSWorkspace.shared.open(url)
         }
     }
@@ -696,85 +759,6 @@ public class TRex: NSObject {
         }.joined(separator: " ")
     }
 
-    func detectText(in image: CGImage, completionHandler: @escaping (String?) -> Void) {
-        logger.info("🔍 detectText (legacy Vision path) called")
-        logger.info("  → Image size: \(image.width, privacy: .public)x\(image.height, privacy: .public)")
-
-        let request = VNRecognizeTextRequest { request, error in
-            if let error = error {
-                self.logger.error("❌ Vision text detection failed: \(error.localizedDescription, privacy: .public)")
-                completionHandler(nil)
-                return
-            }
-
-            guard let result = self.handleDetectionResults(results: request.results) else {
-                self.logger.warning("⚠️ No results from handleDetectionResults")
-                completionHandler(nil)
-                return
-            }
-
-            self.logger.info("✅ Legacy Vision path succeeded: \(result.count, privacy: .public) characters")
-
-            if self.preferences.autoOpenCapturedURL {
-                self.detectAndOpenURL(text: result)
-            }
-            completionHandler(result)
-        }
-
-        // Configure language detection
-        if preferences.automaticLanguageDetection, #available(macOS 13.0, *) {
-            logger.info("🌍 Vision: Automatic language detection ENABLED")
-            request.automaticallyDetectsLanguage = true
-            // Don't set recognitionLanguages when using automatic detection
-        } else {
-            let normalizedLanguage = LanguageCodeMapper.standardize(preferences.recognitionLanguageCode)
-            logger.info("🔤 Vision: Using specific language: \(self.preferences.recognitionLanguageCode, privacy: .public) → normalized to: \(normalizedLanguage, privacy: .public)")
-            request.automaticallyDetectsLanguage = false
-            request.recognitionLanguages = [normalizedLanguage]
-        }
-
-        request.usesLanguageCorrection = true
-        request.recognitionLevel = .accurate
-        request.customWords = preferences.customWordsList
-
-        logger.debug("🔧 Vision request configuration:")
-        logger.debug("  → recognitionLevel: accurate")
-        logger.debug("  → usesLanguageCorrection: true")
-        logger.debug("  → customWords count: \(self.preferences.customWordsList.count, privacy: .public)")
-
-        performDetection(request: request, image: image)
-    }
-
-    private func performDetection(request: VNRecognizeTextRequest, image: CGImage) {
-        let requests = [request]
-
-        let handler = VNImageRequestHandler(cgImage: image, orientation: .up, options: [:])
-
-        do {
-            try handler.perform(requests)
-        } catch {
-            logger.error("Vision handler failed: \(error.localizedDescription, privacy: .public)")
-        }
-    }
-
-    private func handleDetectionResults(results: [Any]?) -> String? {
-        guard let results = results, results.count > 0 else {
-            return nil
-        }
-
-        var output: String = ""
-        for result in results {
-            if let observation = result as? VNRecognizedTextObservation {
-                for text in observation.topCandidates(1) {
-                    if !output.isEmpty {
-                        output.append(preferences.ignoreLineBreaks ? " " : "\n")
-                    }
-                    output.append(text.string)
-                }
-            }
-        }
-        return output
-    }
 }
 
 // MARK: Notifications

--- a/Packages/TRexCore/Sources/TRexCore/TableDetection.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TableDetection.swift
@@ -22,24 +22,39 @@ public struct DetectedTable: Sendable {
     public func toMarkdown() -> String {
         var lines: [String] = []
 
-        let columnCount = headers?.count ?? rows.first?.count ?? 0
+        let columnCount = max(headers?.count ?? 0, rows.map(\.count).max() ?? 0)
         guard columnCount > 0 else { return "" }
+
+        func markdownCell(_ value: String) -> String {
+            value
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "|", with: "\\|")
+                .replacingOccurrences(of: "\r\n", with: "<br>")
+                .replacingOccurrences(of: "\n", with: "<br>")
+                .replacingOccurrences(of: "\r", with: "<br>")
+        }
+
+        func normalizedRow(_ values: [String]) -> [String] {
+            (0..<columnCount).map { index in
+                index < values.count ? markdownCell(values[index]) : ""
+            }
+        }
 
         // Calculate column widths
         var widths = Array(repeating: 3, count: columnCount)
         if let headers = headers {
-            for (i, cell) in headers.enumerated() where i < columnCount {
+            for (i, cell) in normalizedRow(headers).enumerated() {
                 widths[i] = max(widths[i], cell.count)
             }
         }
         for row in rows {
-            for (i, cell) in row.enumerated() where i < columnCount {
+            for (i, cell) in normalizedRow(row).enumerated() {
                 widths[i] = max(widths[i], cell.count)
             }
         }
 
         // Header row (use empty headers when none are provided)
-        let headerCells = headers ?? Array(repeating: "", count: columnCount)
+        let headerCells = normalizedRow(headers ?? [])
         let headerRow = headerCells.enumerated().map { i, cell in
             cell.padding(toLength: widths[i], withPad: " ", startingAt: 0)
         }
@@ -51,16 +66,8 @@ public struct DetectedTable: Sendable {
 
         // Data rows (skip first if it was the header)
         for row in rows {
-            let paddedCells = row.enumerated().map { i, cell -> String in
-                if i < columnCount {
-                    return cell.padding(toLength: widths[i], withPad: " ", startingAt: 0)
-                }
-                return cell
-            }
-            // Pad row if it has fewer cells than columns
-            var cells = paddedCells
-            while cells.count < columnCount {
-                cells.append(String(repeating: " ", count: widths[cells.count]))
+            let cells = normalizedRow(row).enumerated().map { index, cell in
+                cell.padding(toLength: widths[index], withPad: " ", startingAt: 0)
             }
             lines.append("| " + cells.joined(separator: " | ") + " |")
         }
@@ -141,7 +148,7 @@ public struct DetectedTable: Sendable {
     // MARK: - Private helpers
 
     private func escapeCSVField(_ field: String) -> String {
-        if field.contains(",") || field.contains("\"") || field.contains("\n") {
+        if field.contains(",") || field.contains("\"") || field.contains("\n") || field.contains("\r") {
             return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
         }
         return field
@@ -151,6 +158,7 @@ public struct DetectedTable: Sendable {
         return field
             .replacingOccurrences(of: "\t", with: " ")
             .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
     }
 }
 

--- a/Packages/TRexCore/Sources/TRexCore/TesseractOCREngine.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TesseractOCREngine.swift
@@ -6,6 +6,7 @@ import Vision
 public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
     private let tessdataPath: URL
     private let tesseractEngine: TesseractEngine
+    private let recognitionLock = NSLock()
     private let languageDownloader = LanguageDownloader.shared
     
     public init() {
@@ -61,31 +62,11 @@ public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
             }
         }
 
-        // Initialize Tesseract with combined language codes (e.g. "eng+spa")
-        let initializationCode = tesseractCodes.joined(separator: "+")
-        try tesseractEngine.initialize(language: initializationCode)
-        
-        // Set page segmentation mode based on recognition level
-        if recognitionLevel == .accurate {
-            tesseractEngine.setPageSegmentationMode(.auto)
-        } else {
-            tesseractEngine.setPageSegmentationMode(.sparseText)
-        }
-        
-        // Perform OCR
-        let text = try tesseractEngine.recognize(cgImage: image)
-        let confidence = Float(tesseractEngine.confidence()) / 100.0
-        
-        // Clear for memory efficiency
-        tesseractEngine.clear()
-        
-        // Return result
-        return OCRResult(
-            text: text,
-            confidence: confidence,
-            recognizedLanguages: requestedLanguages,
-            engineName: "Tesseract",
-            recognitionLevel: "standard"
+        return try recognizeSynchronously(
+            image: image,
+            requestedLanguages: requestedLanguages,
+            tesseractCodes: tesseractCodes,
+            recognitionLevel: recognitionLevel
         )
     }
     
@@ -124,6 +105,35 @@ public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
 }
 
 private extension TesseractOCREngine {
+    func recognizeSynchronously(
+        image: CGImage,
+        requestedLanguages: [String],
+        tesseractCodes: [String],
+        recognitionLevel: VNRequestTextRecognitionLevel
+    ) throws -> OCRResult {
+        // TesseractEngine is stateful. Serializing initialization, recognition,
+        // confidence reads, and cleanup prevents overlapping captures from
+        // corrupting its native state.
+        recognitionLock.lock()
+        defer { recognitionLock.unlock() }
+
+        let initializationCode = tesseractCodes.joined(separator: "+")
+        try tesseractEngine.initialize(language: initializationCode)
+        defer { tesseractEngine.clear() }
+
+        tesseractEngine.setPageSegmentationMode(recognitionLevel == .accurate ? .auto : .sparseText)
+        let text = try tesseractEngine.recognize(cgImage: image)
+        let confidence = Float(tesseractEngine.confidence()) / 100.0
+
+        return OCRResult(
+            text: text,
+            confidence: confidence,
+            recognizedLanguages: requestedLanguages,
+            engineName: "Tesseract",
+            recognitionLevel: recognitionLevel == .accurate ? "accurate" : "fast"
+        )
+    }
+
     func languageFileURL(forTesseractCode code: String) -> URL {
         tessdataPath.appendingPathComponent("\(code).traineddata")
     }

--- a/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
@@ -181,20 +181,24 @@ public final class WatchModeManager: ObservableObject {
             return // No change detected
         }
 
-        lastImageHash = hash
         logger.info("Change detected in watched region (capture #\(self.captureCount + 1, privacy: .public))")
 
         // Run OCR on the captured image
         guard let ocrResult = await TRex.shared.recognizeImageForWatchMode(image) else {
             logger.warning("OCR returned no result for watched region")
+            lastImageHash = hash
             return
         }
 
         let text = ocrResult.text
-        guard !text.isEmpty else { return }
+        guard !text.isEmpty else {
+            lastImageHash = hash
+            return
+        }
 
+        guard handleOutput(text) else { return }
+        lastImageHash = hash
         captureCount += 1
-        handleOutput(text)
     }
 
     // MARK: - Screen Capture
@@ -276,18 +280,20 @@ public final class WatchModeManager: ObservableObject {
 
     // MARK: - Output Handlers
 
-    private func handleOutput(_ text: String) {
+    @discardableResult
+    private func handleOutput(_ text: String) -> Bool {
         switch outputMode {
         case .appendToClipboard:
-            appendToClipboard(text)
+            return appendToClipboard(text)
         case .appendToFile:
-            appendToFile(text)
+            return appendToFile(text)
         case .notificationStream:
             showNotification(text)
+            return true
         }
     }
 
-    private func appendToClipboard(_ text: String) {
+    private func appendToClipboard(_ text: String) -> Bool {
         let pasteboard = NSPasteboard.general
         let combined: String
         if clipboardAccumulator.isEmpty {
@@ -298,7 +304,9 @@ public final class WatchModeManager: ObservableObject {
         pasteboard.clearContents()
         if pasteboard.setString(combined, forType: .string) {
             clipboardAccumulator = combined
+            return true
         }
+        return false
     }
 
     private func resetClipboardAccumulator() {
@@ -308,25 +316,28 @@ public final class WatchModeManager: ObservableObject {
     /// Resolve and validate the output file path.
     /// Paths from external sources (e.g. URL scheme) are restricted to user-writable
     /// locations under the user's home directory to prevent path injection.
-    private static func sanitizedOutputURL(from path: String?) -> URL? {
+    static func sanitizedOutputURL(from path: String?) -> URL? {
         guard let path, !path.isEmpty else { return nil }
 
         let fileURL = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
             .standardizedFileURL
+            .resolvingSymlinksInPath()
 
         // Reject paths outside the user's home directory
-        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
-        guard fileURL.path.hasPrefix(home.path) else {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard fileURL.path.hasPrefix(home.path + "/") else {
             return nil
         }
 
         return fileURL
     }
 
-    private func appendToFile(_ text: String) {
+    private func appendToFile(_ text: String) -> Bool {
         guard let validURL = Self.sanitizedOutputURL(from: outputFilePath) else {
             logger.error("No valid output file path configured for watch mode")
-            return
+            return false
         }
 
         let timestamp = ISO8601DateFormatter().string(from: Date())
@@ -343,8 +354,10 @@ public final class WatchModeManager: ObservableObject {
             } else {
                 try entry.write(to: validURL, atomically: true, encoding: .utf8)
             }
+            return true
         } catch {
             logger.error("Failed to write to watch mode output file: \(error.localizedDescription, privacy: .public)")
+            return false
         }
     }
 

--- a/Packages/TRexCore/Tests/TRexCoreTests/BugRegressionTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/BugRegressionTests.swift
@@ -1,0 +1,62 @@
+import AppKit
+import Vision
+import XCTest
+
+@testable import TRexCore
+
+final class BugRegressionTests: XCTestCase {
+    func testRegisteringSameEngineIdentifierReplacesExistingEngine() {
+        let manager = OCRManager.shared
+        let originalVision = manager.engines.first { $0.identifier == "vision" }
+        let originalCount = manager.engines.count
+
+        manager.registerEngine(StubOCREngine(identifier: "vision", priority: 999))
+
+        XCTAssertEqual(manager.engines.count, originalCount)
+        XCTAssertEqual(manager.engines.filter { $0.identifier == "vision" }.count, 1)
+        XCTAssertEqual(manager.engines.first { $0.identifier == "vision" }?.priority, 999)
+
+        if let originalVision {
+            manager.registerEngine(originalVision)
+        }
+    }
+
+    @MainActor
+    func testURLDetectionHandlesUnicodeBeforeURL() {
+        let urls = TRex.detectedURLs(in: "Receipt 🧭 — visit example.com/account")
+
+        XCTAssertEqual(urls.map(\.absoluteString), ["https://example.com/account"])
+    }
+
+    @MainActor
+    func testWatchOutputRejectsSiblingPathWithHomePrefix() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
+        let siblingPath = home.path + "-outside/capture.txt"
+
+        XCTAssertNil(WatchModeManager.sanitizedOutputURL(from: siblingPath))
+        XCTAssertNotNil(WatchModeManager.sanitizedOutputURL(from: home.appendingPathComponent("capture.txt").path))
+    }
+}
+
+private struct StubOCREngine: OCREngine {
+    let identifier: String
+    let priority: Int
+    let name = "Stub"
+
+    func supportsLanguage(_ language: String) -> Bool { true }
+
+    func recognizeText(
+        in image: CGImage,
+        languages: [String],
+        recognitionLevel: VNRequestTextRecognitionLevel
+    ) async throws -> OCRResult {
+        OCRResult(text: "", confidence: 0, recognizedLanguages: languages)
+    }
+
+    func recognizeText(
+        in image: CGImage,
+        recognitionLevel: VNRequestTextRecognitionLevel
+    ) async throws -> OCRResult {
+        OCRResult(text: "", confidence: 0, recognizedLanguages: [])
+    }
+}

--- a/Packages/TRexCore/Tests/TRexCoreTests/TableDetectionTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/TableDetectionTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import TRexCore
+
+final class TableDetectionTests: XCTestCase {
+    func testMarkdownEscapesPipesAndNormalizesUnevenRows() {
+        let table = DetectedTable(
+            headers: ["Name", "Status"],
+            rows: [
+                ["A | B", "Ready", "Extra"],
+                ["Second"]
+            ]
+        )
+
+        let lines = table.toMarkdown().split(separator: "\n", omittingEmptySubsequences: false)
+
+        XCTAssertEqual(lines.count, 4)
+        XCTAssertTrue(lines[0].contains("| Name"))
+        XCTAssertTrue(lines[0].contains("Status"))
+        XCTAssertTrue(lines[1].contains("---"))
+        XCTAssertTrue(lines[2].contains("A \\| B"))
+        XCTAssertTrue(lines[2].contains("Extra"))
+        XCTAssertTrue(lines[3].contains("Second"))
+        XCTAssertTrue(lines.allSatisfy { $0.hasPrefix("| ") && $0.hasSuffix(" |") })
+    }
+
+    func testCSVQuotesCarriageReturns() {
+        let table = DetectedTable(headers: nil, rows: [["first\rsecond", "ok"]])
+
+        XCTAssertEqual(table.toCSV(), "\"first\rsecond\",ok")
+    }
+
+    func testTSVRemovesAllEmbeddedLineBreaks() {
+        let table = DetectedTable(headers: nil, rows: [["first\r\nsecond", "ok"]])
+
+        XCTAssertEqual(table.toTSV(), "first  second\tok")
+    }
+}

--- a/Packages/TRexCore/Tests/TRexCoreTests/TimeoutTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/TimeoutTests.swift
@@ -25,4 +25,24 @@ final class TimeoutTests: XCTestCase {
             }
         }
     }
+
+    func testWithTimeoutDoesNotWaitForUncooperativeOperation() async {
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        do {
+            _ = try await withTimeout(seconds: 0.05) {
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                        continuation.resume(returning: "late")
+                    }
+                }
+            }
+            XCTFail("Expected timeout")
+        } catch TimeoutError.timedOut {
+            XCTAssertLessThan(start.duration(to: clock.now), .milliseconds(250))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }

--- a/Packages/TRexLLM/Sources/TRexLLM/Models/LLMConfiguration.swift
+++ b/Packages/TRexLLM/Sources/TRexLLM/Models/LLMConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Configuration for LLM integration
-public struct LLMConfiguration: Codable {
+public struct LLMConfiguration: Codable, Sendable {
     // OCR Provider settings
     public var ocrProvider: LLMProviderType
     public var ocrAPIKey: String?
@@ -100,7 +100,7 @@ public struct LLMConfiguration: Codable {
 }
 
 /// LLM provider types
-public enum LLMProviderType: String, Codable, CaseIterable {
+public enum LLMProviderType: String, Codable, CaseIterable, Sendable {
     case openai = "OpenAI"
     case anthropic = "Anthropic"
     case custom = "Custom"

--- a/Packages/TRexLLM/Sources/TRexLLM/Providers/UnifiedLanguageModelProvider.swift
+++ b/Packages/TRexLLM/Sources/TRexLLM/Providers/UnifiedLanguageModelProvider.swift
@@ -10,11 +10,10 @@ public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendabl
         let mimeType: String
     }
 
-    public var name: String
-    public var supportedModels: [String]
+    public let name: String
+    public let supportedModels: [String]
 
-    private var model: any LanguageModel
-    private var session: LanguageModelSession
+    private let model: any LanguageModel
 
     /// Initialize with provider type
     public init(providerType: LLMProviderType, apiKey: String?, endpoint: String?, modelName: String) throws {
@@ -29,8 +28,11 @@ public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendabl
 
             // Use custom endpoint if provided (for OpenAI-compatible services)
             if let customEndpoint = endpoint, !customEndpoint.isEmpty {
+                guard let baseURL = Self.validatedEndpoint(customEndpoint) else {
+                    throw LLMError.invalidEndpoint
+                }
                 self.model = OpenAILanguageModel(
-                    baseURL: URL(string: customEndpoint)!,
+                    baseURL: baseURL,
                     apiKey: key,
                     model: modelName
                 )
@@ -63,7 +65,7 @@ public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendabl
             // bridge so a bare install still talks to a local server.
             let baseURL: URL
             if let customEndpoint = endpoint, !customEndpoint.isEmpty {
-                guard let url = URL(string: customEndpoint) else {
+                guard let url = Self.validatedEndpoint(customEndpoint) else {
                     throw LLMError.invalidEndpoint
                 }
                 baseURL = url
@@ -86,18 +88,26 @@ public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendabl
             if #available(macOS 26.0, *) {
                 self.model = SystemLanguageModel.default
             } else {
-                throw LLMError.modelNotAvailable("Apple Intelligence requires macOS 15.1 (Sequoia) or later")
+                throw LLMError.modelNotAvailable("Apple Foundation Models require macOS 26 or later")
             }
         }
-
-        self.session = LanguageModelSession(model: model)
     }
 
     init(model: any LanguageModel) {
         self.name = "Test"
         self.supportedModels = []
         self.model = model
-        self.session = LanguageModelSession(model: model)
+    }
+
+    static func validatedEndpoint(_ value: String) -> URL? {
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              components.host?.isEmpty == false,
+              let url = components.url else {
+            return nil
+        }
+        return url
     }
 
     /// Perform OCR using a vision-capable LLM.
@@ -141,13 +151,14 @@ public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendabl
         prompt: String,
         model: String
     ) async throws -> String {
-        // Replace {text} placeholder in prompt
-        let fullPrompt = prompt.replacingOccurrences(of: "{text}", with: text)
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedPrompt = trimmedPrompt.isEmpty ? PromptTemplates.defaultPostProcessPrompt : trimmedPrompt
+        let fullPrompt = resolvedPrompt.replacingOccurrences(of: "{text}", with: text)
 
         // For Apple, use instructions-based approach
         if case .apple = self.getProviderType() {
             if #available(macOS 26.0, *) {
-                let instructions = Instructions(prompt)
+                let instructions = Instructions(resolvedPrompt.replacingOccurrences(of: "{text}", with: "the supplied text"))
                 let sessionWithInstructions = LanguageModelSession(
                     model: self.model,
                     instructions: instructions
@@ -155,12 +166,15 @@ public final class UnifiedLanguageModelProvider: LLMProvider, @unchecked Sendabl
                 let response = try await sessionWithInstructions.respond(to: Prompt(text))
                 return response.content
             } else {
-                throw LLMError.modelNotAvailable("Apple Intelligence requires macOS 15.1 (Sequoia) or later")
+                throw LLMError.modelNotAvailable("Apple Foundation Models require macOS 26 or later")
             }
         }
 
         // For other providers, use the full prompt directly
-        let response = try await session.respond(to: Prompt(fullPrompt))
+        // A fresh session prevents one capture's contents from leaking into the
+        // next request and avoids unbounded conversation context growth.
+        let textSession = LanguageModelSession(model: self.model)
+        let response = try await textSession.respond(to: Prompt(fullPrompt))
         return response.content
     }
 

--- a/Packages/TRexLLM/Sources/TRexLLM/Utils/ImagePreprocessor.swift
+++ b/Packages/TRexLLM/Sources/TRexLLM/Utils/ImagePreprocessor.swift
@@ -81,21 +81,41 @@ public class ImagePreprocessor {
     }
 
     private func reduceSize(_ image: CGImage, targetSize: Int) throws -> Data {
-        var quality: CGFloat = 0.85
+        var workingImage = image
 
-        while quality > 0.3 {
-            if let data = convertToJPEG(image, quality: quality), data.count <= targetSize {
-                return data
+        while max(workingImage.width, workingImage.height) >= 256 {
+            var quality: CGFloat = 0.8
+            while quality >= 0.3 {
+                if let data = convertToJPEG(workingImage, quality: quality), data.count <= targetSize {
+                    return data
+                }
+                quality -= 0.1
             }
-            quality -= 0.05
+
+            guard let smallerImage = resize(workingImage, scale: 0.8) else { break }
+            workingImage = smallerImage
         }
 
-        // Last resort: use minimum quality
-        guard let data = convertToJPEG(image, quality: 0.3) else {
-            throw LLMError.imageProcessingFailed
-        }
+        throw LLMError.imageProcessingFailed
+    }
 
-        return data
+    private func resize(_ image: CGImage, scale: CGFloat) -> CGImage? {
+        let width = max(1, Int(CGFloat(image.width) * scale))
+        let height = max(1, Int(CGFloat(image.height) * scale))
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()
     }
 
     /// Convert image data to base64 string

--- a/Packages/TRexLLM/Sources/TRexLLM/Utils/NetworkChecker.swift
+++ b/Packages/TRexLLM/Sources/TRexLLM/Utils/NetworkChecker.swift
@@ -6,10 +6,13 @@ import os
 public final class NetworkChecker: Sendable {
     private let monitor: NWPathMonitor
     private let queue = DispatchQueue(label: "com.trex.llm.network")
-    private let _isConnected: OSAllocatedUnfairLock<Bool>
+    private let _isConnected: OSAllocatedUnfairLock<Bool?>
 
     public init() {
-        _isConnected = OSAllocatedUnfairLock(initialState: false)
+        // NWPathMonitor reports asynchronously. Treat the initial unknown state
+        // optimistically so an OCR request made immediately after launch is not
+        // incorrectly rejected before the first path update arrives.
+        _isConnected = OSAllocatedUnfairLock(initialState: nil)
         monitor = NWPathMonitor()
         let isConnected = _isConnected
         monitor.pathUpdateHandler = { path in
@@ -25,7 +28,7 @@ public final class NetworkChecker: Sendable {
     /// Check if network is available
     /// - Returns: True if network is available
     public func isNetworkAvailable() -> Bool {
-        return _isConnected.withLock { $0 }
+        return _isConnected.withLock { $0 ?? true }
     }
 
     /// Check connectivity to a specific host
@@ -33,7 +36,7 @@ public final class NetworkChecker: Sendable {
     /// - Returns: True if host is reachable
     public func checkConnectivity(to url: URL) async -> Bool {
         // Quick check if network is available at all
-        guard _isConnected.withLock({ $0 }) else {
+        guard _isConnected.withLock({ $0 ?? true }) else {
             return false
         }
 

--- a/Packages/TRexLLM/Tests/TRexLLMTests/ImagePreprocessorTests.swift
+++ b/Packages/TRexLLM/Tests/TRexLLMTests/ImagePreprocessorTests.swift
@@ -46,6 +46,6 @@ final class ImagePreprocessorTests: XCTestCase {
         let data = try preprocessor.preprocess(image)
 
         // The preprocessed image should be smaller than 2MB target
-        XCTAssertLessThan(data.count, 2_500_000)
+        XCTAssertLessThanOrEqual(data.count, 2_097_152)
     }
 }

--- a/Packages/TRexLLM/Tests/TRexLLMTests/LLMProviderIntegrationTests.swift
+++ b/Packages/TRexLLM/Tests/TRexLLMTests/LLMProviderIntegrationTests.swift
@@ -193,6 +193,21 @@ final class LLMProviderIntegrationTests: XCTestCase {
         }
     }
 
+    func testOpenAIProviderRejectsMalformedCustomEndpoint() {
+        XCTAssertThrowsError(
+            try UnifiedLanguageModelProvider(
+                providerType: .openai,
+                apiKey: "test-key",
+                endpoint: "relative/path",
+                modelName: "gpt-4.1-mini"
+            )
+        ) { error in
+            guard case LLMError.invalidEndpoint = error else {
+                return XCTFail("Expected invalidEndpoint error, got: \(error)")
+            }
+        }
+    }
+
     // MARK: - Text Processing (OpenAI)
 
     func testOpenAITextProcessing() async throws {

--- a/Packages/TRexLLM/Tests/TRexLLMTests/UnifiedLanguageModelProviderTests.swift
+++ b/Packages/TRexLLM/Tests/TRexLLMTests/UnifiedLanguageModelProviderTests.swift
@@ -46,6 +46,32 @@ final class UnifiedLanguageModelProviderTests: XCTestCase {
         XCTAssertEqual(summaries.map(\.imageCount), [1, 1])
     }
 
+    func testProcessTextUsesFreshSessionForEachCapture() async throws {
+        let recorder = TranscriptRecorder()
+        let provider = UnifiedLanguageModelProvider(model: RecordingLanguageModel(recorder: recorder))
+
+        _ = try await provider.processText("first", prompt: "Clean: {text}", model: "test")
+        _ = try await provider.processText("second", prompt: "Clean: {text}", model: "test")
+
+        let summaries = await recorder.summaries
+        XCTAssertEqual(summaries.map(\.entryCount), [1, 1])
+        XCTAssertEqual(summaries.map(\.imageCount), [0, 0])
+    }
+
+    func testEndpointValidationRequiresAbsoluteHTTPURL() {
+        XCTAssertEqual(
+            UnifiedLanguageModelProvider.validatedEndpoint("http://localhost:11434/v1")?.absoluteString,
+            "http://localhost:11434/v1"
+        )
+        XCTAssertEqual(
+            UnifiedLanguageModelProvider.validatedEndpoint("https://example.com/v1")?.absoluteString,
+            "https://example.com/v1"
+        )
+        XCTAssertNil(UnifiedLanguageModelProvider.validatedEndpoint("relative/path"))
+        XCTAssertNil(UnifiedLanguageModelProvider.validatedEndpoint("file:///tmp/socket"))
+        XCTAssertNil(UnifiedLanguageModelProvider.validatedEndpoint("http://has space/v1"))
+    }
+
     private func makeTestImage() -> NSImage {
         let size = NSSize(width: 120, height: 80)
         let image = NSImage(size: size)

--- a/TRex CMD/main.swift
+++ b/TRex CMD/main.swift
@@ -39,6 +39,12 @@ struct trex: AsyncParsableCommand {
 
         let mode: InvocationMode
         var imagePath: String?
+        var temporaryInputURL: URL?
+        defer {
+            if let temporaryInputURL {
+                try? FileManager.default.removeItem(at: temporaryInputURL)
+            }
+        }
 
         if clipboard {
             mode = automation ? .captureClipboardAndTriggerAutomation : .captureClipboard
@@ -49,14 +55,16 @@ struct trex: AsyncParsableCommand {
             guard !data.isEmpty else {
                 throw CLIError.stdinEmpty
             }
-            let tempPath = NSTemporaryDirectory() + "trex-stdin-\(UUID().uuidString).png"
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("trex-stdin-\(UUID().uuidString).png")
             do {
-                try data.write(to: URL(fileURLWithPath: tempPath))
+                try data.write(to: tempURL)
             } catch {
-                throw CLIError.tempFileWriteFailed(path: tempPath, underlying: error)
+                throw CLIError.tempFileWriteFailed(path: tempURL.path, underlying: error)
             }
             mode = automation ? .captureFromFileAndTriggerAutomation : .captureFromFile
-            imagePath = tempPath
+            imagePath = tempURL.path
+            temporaryInputURL = tempURL
         } else {
             mode = automation ? .captureScreenAndTriggerAutomation : .captureScreen
         }

--- a/TRex.xcodeproj/project.pbxproj
+++ b/TRex.xcodeproj/project.pbxproj
@@ -512,6 +512,7 @@
 				FA1E99FC2EF77006002A457E /* Frameworks */,
 				FA1E9A012EF77006002A457E /* Resources */,
 				FA1E9A082EF77006002A457E /* Embed Frameworks */,
+				FAC3F8E12F3A0000006C4A56 /* Normalize Embedded Frameworks */,
 				FA1E9A092EF77006002A457E /* Version */,
 			);
 			buildRules = (
@@ -745,6 +746,26 @@
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n#if which swiftformat >/dev/null; then\n # swiftformat --swiftversion \"5.7.0\" \"$SRCROOT\"\n#else\n # echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n#fi\n";
 		};
+		FAC3F8E12F3A0000006C4A56 /* Normalize Embedded Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Scripts/flatten-frameworks.sh",
+			);
+			name = "Normalize Embedded Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/Scripts/flatten-frameworks.sh\" \"$TARGET_BUILD_DIR/$FULL_PRODUCT_NAME\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -883,6 +904,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"TRex/Preview Content\"";
 				DEVELOPMENT_TEAM = X93LWC49WV;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = TRex/Resources/info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
@@ -890,7 +912,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MAC_APP_STORE = YES;
 				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = "";
@@ -920,6 +942,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"TRex/Preview Content\"";
 				DEVELOPMENT_TEAM = X93LWC49WV;
 				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = TRex/Resources/info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
@@ -927,7 +950,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MAC_APP_STORE = YES;
 				MARKETING_VERSION = 2.0.0;
 				OTHER_LDFLAGS = "-lc++";
@@ -1117,7 +1140,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 149;
+				CURRENT_PROJECT_VERSION = 162;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"TRex/Preview Content\"";
 				DEVELOPMENT_TEAM = X93LWC49WV;
@@ -1131,7 +1154,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MAC_APP_STORE = NO;
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = "";
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ameba.TRex;
@@ -1153,7 +1176,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 149;
+				CURRENT_PROJECT_VERSION = 162;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"TRex/Preview Content\"";
 				DEVELOPMENT_TEAM = X93LWC49WV;
@@ -1167,7 +1190,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MAC_APP_STORE = NO;
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 2.0.0;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ameba.TRex;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TRex/App/UI/MenuBarItem.swift
+++ b/TRex/App/UI/MenuBarItem.swift
@@ -349,9 +349,6 @@ extension MenubarItem: NSMenuDelegate {
         historyItem.submenu = submenu
     }
 
-    func menuDidClose(_: NSMenu) {
-        NSApp.activate(ignoringOtherApps: true)
-    }
 }
 
 extension MenubarItem: NSWindowDelegate, NSDraggingDestination {
@@ -367,12 +364,14 @@ extension MenubarItem: NSWindowDelegate, NSDraggingDestination {
             filesURL = urls
         }
 
-        if !filesURL.isEmpty, let imagePath = filesURL.first?.path {
-            Task {
-                await trex.capture(.captureFromFile, imagePath: imagePath)
-            }
+        guard let imageURL = filesURL.first,
+              NSImage(contentsOf: imageURL) != nil else {
+            return false
         }
 
+        Task {
+            await trex.capture(.captureFromFile, imagePath: imageURL.path)
+        }
         return true
     }
 }

--- a/TRex/App/UI/Onboarding/Extensions/View+OnboardingStyle.swift
+++ b/TRex/App/UI/Onboarding/Extensions/View+OnboardingStyle.swift
@@ -27,11 +27,20 @@ extension View {
     }
     
     func fadeInAnimation(delay: TimeInterval = 0) -> some View {
-        self
-            .opacity(0)
+        modifier(FadeInModifier(delay: delay))
+    }
+}
+
+private struct FadeInModifier: ViewModifier {
+    let delay: TimeInterval
+    @State private var isVisible = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isVisible ? 1 : 0)
             .onAppear {
                 withAnimation(Animation.brandEaseOut(delay: delay)) {
-                    self.opacity(1)
+                    isVisible = true
                 }
             }
     }

--- a/TRex/App/UI/Onboarding/ViewModels/SetupViewModel.swift
+++ b/TRex/App/UI/Onboarding/ViewModels/SetupViewModel.swift
@@ -46,28 +46,37 @@ class SetupViewModel: ObservableObject {
     func checkScreenRecordingPermission() {
         screenRecordingPermission = CGPreflightScreenCaptureAccess()
         
-        if activeSection == .permissions {
+        if activeSection == .permissions, !screenRecordingPermission {
             startPermissionMonitoring()
+        } else {
+            stopPermissionMonitoring()
         }
     }
     
     func openSystemPreferences() {
-        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") else { return }
+        NSWorkspace.shared.open(url)
     }
     
     private func startPermissionMonitoring() {
         permissionTimer?.invalidate()
-        permissionTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+        permissionTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             let newStatus = CGPreflightScreenCaptureAccess()
-            if newStatus != self.screenRecordingPermission {
-                withAnimation(Animation.brandSpring) {
-                    self.screenRecordingPermission = newStatus
+            Task { @MainActor in
+                guard let self else { return }
+                if newStatus != self.screenRecordingPermission {
+                    withAnimation(Animation.brandSpring) {
+                        self.screenRecordingPermission = newStatus
+                    }
+                }
+                if newStatus {
+                    self.stopPermissionMonitoring()
                 }
             }
         }
     }
     
-    private func stopPermissionMonitoring() {
+    func stopPermissionMonitoring() {
         permissionTimer?.invalidate()
         permissionTimer = nil
     }

--- a/TRex/App/UI/Onboarding/Views/SetupSections/PermissionsSection.swift
+++ b/TRex/App/UI/Onboarding/Views/SetupSections/PermissionsSection.swift
@@ -52,7 +52,11 @@ struct PermissionsSection: View {
             VStack(alignment: .leading, spacing: 15) {
                 PrivacyPoint(icon: "lock.fill", text: "Your privacy is protected", color: .green)
                 PrivacyPoint(icon: "hand.raised.fill", text: "Only captures when you trigger", color: .blue)
-                PrivacyPoint(icon: "externaldrive.fill", text: "No data stored or transmitted", color: .purple)
+                PrivacyPoint(
+                    icon: "externaldrive.fill",
+                    text: "Captures stay on your Mac unless you enable LLM features",
+                    color: .purple
+                )
             }
         }
     }

--- a/TRex/App/UI/Onboarding/Views/SetupView.swift
+++ b/TRex/App/UI/Onboarding/Views/SetupView.swift
@@ -52,8 +52,11 @@ struct SetupView: View {
             animateContent = true
             preferences.recognitionLanguageCode = vm.selectedLanguageCode
         }
-        .onChange(of: vm.selectedLanguageCode) { newValue in
+        .onChange(of: vm.selectedLanguageCode) { _, newValue in
             preferences.recognitionLanguageCode = newValue
+        }
+        .onDisappear {
+            vm.stopPermissionMonitoring()
         }
     }
 }

--- a/TRex/App/UI/Settings/GeneralSettingsView.swift
+++ b/TRex/App/UI/Settings/GeneralSettingsView.swift
@@ -55,9 +55,14 @@ struct GeneralSettingsView: View {
                         .foregroundColor(Color(NSColor.controlBackgroundColor))
                     HStack {
                         ForEach(Preferences.MenuBarIcon.allCases, id: \.self) { item in
-                            MenuBarIconView(item: item, selected: $preferences.menuBarIcon).onTapGesture {
+                            Button {
                                 preferences.menuBarIcon = item
+                            } label: {
+                                MenuBarIconView(item: item, selected: $preferences.menuBarIcon)
                             }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Menu bar icon \(item.rawValue)")
+                            .accessibilityAddTraits(preferences.menuBarIcon == item ? .isSelected : [])
                         }
                     }
                 }.frame(height: 70)
@@ -320,8 +325,10 @@ struct CLIInstallRow: View {
         }
 
         // Fetch all releases to find matching version
-        let allReleasesURL = URL(string: "https://api.github.com/repos/amebalabs/TRex/releases")!
-        let (allData, _) = try await URLSession.shared.data(from: allReleasesURL)
+        guard let allReleasesURL = URL(string: "https://api.github.com/repos/amebalabs/TRex/releases") else {
+            throw CLIInstallError.invalidDownloadURL
+        }
+        let allData = try await downloadData(from: allReleasesURL)
         let allReleases = try JSONDecoder().decode([GitHubRelease].self, from: allData)
 
         // Find release matching current app version
@@ -359,18 +366,24 @@ struct CLIInstallRow: View {
         await MainActor.run { downloadProgress = 0.2 }
 
         // Download checksum file
-        let (checksumData, _) = try await URLSession.shared.data(from: URL(string: checksumAsset.browserDownloadURL)!)
-        let checksumString = String(data: checksumData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let expectedChecksum = checksumString.components(separatedBy: " ").first ?? ""
+        guard let checksumURL = URL(string: checksumAsset.browserDownloadURL),
+              let binaryURL = URL(string: cliAsset.browserDownloadURL) else {
+            throw CLIInstallError.invalidDownloadURL
+        }
 
-        guard !expectedChecksum.isEmpty else {
+        let checksumData = try await downloadData(from: checksumURL)
+        let checksumString = String(data: checksumData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let expectedChecksum = checksumString.split(whereSeparator: \.isWhitespace).first.map(String.init) ?? ""
+
+        guard expectedChecksum.count == 64,
+              expectedChecksum.allSatisfy(\.isHexDigit) else {
             throw CLIInstallError.invalidChecksum
         }
 
         await MainActor.run { downloadProgress = 0.4 }
 
         // Download CLI binary
-        let (binaryData, _) = try await URLSession.shared.data(from: URL(string: cliAsset.browserDownloadURL)!)
+        let binaryData = try await downloadData(from: binaryURL)
 
         await MainActor.run { downloadProgress = 0.6 }
 
@@ -378,45 +391,30 @@ struct CLIInstallRow: View {
         let computedChecksum = SHA256.hash(data: binaryData)
         let computedChecksumString = computedChecksum.compactMap { String(format: "%02x", $0) }.joined()
 
-        guard computedChecksumString == expectedChecksum else {
+        guard computedChecksumString.caseInsensitiveCompare(expectedChecksum) == .orderedSame else {
             throw CLIInstallError.checksumMismatch
         }
 
         await MainActor.run { downloadProgress = 0.8 }
 
-        // Create a uniquely named temp file to avoid conflicts
-        let tempDir = FileManager.default.temporaryDirectory
-        let uniqueFilename = "trex-\(UUID().uuidString)"
-        let tempURL = tempDir.appendingPathComponent(uniqueFilename)
-
-        // Ensure cleanup
-        defer {
-            try? FileManager.default.removeItem(at: tempURL)
-        }
-
-        // Write binary to temp location
-        try binaryData.write(to: tempURL, options: .atomic)
-
-        // Verify file exists before trying to install
-        guard FileManager.default.fileExists(atPath: tempURL.path) else {
-            throw CLIInstallError.installationFailed("Failed to write temporary file")
-        }
-
         // Create ~/.local/bin directory if it doesn't exist
         let installURL = URL(fileURLWithPath: installPath)
         let binDir = installURL.deletingLastPathComponent()
+        let stagedURL = binDir.appendingPathComponent(".trex-\(UUID().uuidString).tmp")
 
         try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true, attributes: nil)
+        defer { try? FileManager.default.removeItem(at: stagedURL) }
 
-        // Copy binary to install location
-        // Remove existing file if present
+        // Stage and permission the replacement in the destination directory so
+        // replacing an existing CLI is atomic and never leaves a partial binary.
+        try binaryData.write(to: stagedURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stagedURL.path)
+
         if FileManager.default.fileExists(atPath: installPath) {
-            try FileManager.default.removeItem(atPath: installPath)
+            _ = try FileManager.default.replaceItemAt(installURL, withItemAt: stagedURL)
+        } else {
+            try FileManager.default.moveItem(at: stagedURL, to: installURL)
         }
-
-        try FileManager.default.copyItem(at: tempURL, to: installURL)
-
-        // Make executable (chmod +x)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: installPath)
 
         // Verify installation succeeded
@@ -425,6 +423,15 @@ struct CLIInstallRow: View {
         }
 
         await MainActor.run { downloadProgress = 1.0 }
+    }
+
+    private func downloadData(from url: URL) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw CLIInstallError.httpError((response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+        return data
     }
 }
 
@@ -438,6 +445,8 @@ enum CLIInstallError: LocalizedError {
     case noMatchingRelease(version: String)
     case noCliInRelease(version: String)
     case userCancelled
+    case invalidDownloadURL
+    case httpError(Int)
 
     var errorDescription: String? {
         switch self {
@@ -459,6 +468,10 @@ enum CLIInstallError: LocalizedError {
             return "Version \(version) doesn't include CLI. Please check for app updates."
         case .userCancelled:
             return "Installation cancelled by user"
+        case .invalidDownloadURL:
+            return "Release contains an invalid download URL"
+        case .httpError(let statusCode):
+            return "Download failed with HTTP status \(statusCode)"
         }
     }
 }

--- a/TRex/App/UI/Settings/LLMSettingsView.swift
+++ b/TRex/App/UI/Settings/LLMSettingsView.swift
@@ -78,7 +78,7 @@ struct LLMSettingsView: View {
 
                                 Toggle("", isOn: $preferences.llmFallbackToBuiltIn)
                                     .toggleStyle(SwitchToggleStyle())
-                                    .onChange(of: preferences.llmFallbackToBuiltIn) { _ in
+                                    .onChange(of: preferences.llmFallbackToBuiltIn) {
                                         TRex.shared.initializeLLM()
                                     }
                             }
@@ -212,7 +212,7 @@ private struct SettingsCardHeader: View {
 
             Toggle("", isOn: $isOn)
                 .toggleStyle(SwitchToggleStyle())
-                .onChange(of: isOn) { _ in
+                .onChange(of: isOn) {
                     onChange()
                 }
         }
@@ -254,11 +254,13 @@ private struct ProviderConfigSection: View {
                     Text("Anthropic").tag("Anthropic")
                     Text("Custom").tag("Custom")
                     if includeApple {
-                        Text("Apple").tag("Apple")
+                        if #available(macOS 26.0, *) {
+                            Text("Apple").tag("Apple")
+                        }
                     }
                 }
                 .pickerStyle(SegmentedPickerStyle())
-                .onChange(of: provider) { _ in
+                .onChange(of: provider) {
                     onChange()
                 }
             }
@@ -269,7 +271,7 @@ private struct ProviderConfigSection: View {
                     Image(systemName: "apple.logo")
                         .font(.system(size: 11))
                         .foregroundColor(.secondary)
-                    Text("On-device Apple Intelligence (requires macOS 15.1+)")
+                    Text("On-device Apple Foundation Models (requires macOS 26+)")
                         .font(.system(size: 11))
                         .foregroundColor(.secondary)
                 }
@@ -283,7 +285,7 @@ private struct ProviderConfigSection: View {
                         HStack(spacing: 4) {
                             SecureField(apiKeyIsOptional ? "API key (optional)" : "Enter API key", text: $apiKey)
                                 .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .onChange(of: apiKey) { _ in
+                                .onChange(of: apiKey) {
                                     onChange()
                                 }
 
@@ -311,7 +313,7 @@ private struct ProviderConfigSection: View {
                     VStack(alignment: .leading, spacing: 4) {
                         TextField("http://localhost:11434/v1", text: $customEndpoint)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
-                            .onChange(of: customEndpoint) { _ in
+                            .onChange(of: customEndpoint) {
                                 onChange()
                             }
 
@@ -327,7 +329,7 @@ private struct ProviderConfigSection: View {
                 SettingsFormRow(label: "Model") {
                     TextField(modelPlaceholder, text: $model)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .onChange(of: model) { _ in
+                        .onChange(of: model) {
                             onChange()
                         }
                 }

--- a/TRex/App/UI/Settings/SettingsView.swift
+++ b/TRex/App/UI/Settings/SettingsView.swift
@@ -4,7 +4,10 @@ import TRexCore
 
 struct SettingsView: View {
     private enum Tabs: Hashable {
-        case general, shortcuts, about, automation, customWords, tesseract, llm
+        case general, shortcuts, about, automation, customWords, tesseract
+        #if !MAC_APP_STORE
+        case llm
+        #endif
     }
 
     var body: some View {
@@ -44,11 +47,13 @@ struct SettingsView: View {
                     Label("Tesseract", systemImage: "text.viewfinder")
                 }
                 .tag(Tabs.tesseract)
-            LLMSettingsView()
-                .tabItem {
-                    Label("AI", systemImage: "sparkles")
-                }
-                .tag(Tabs.llm)
+            #if !MAC_APP_STORE
+                LLMSettingsView()
+                    .tabItem {
+                        Label("AI", systemImage: "sparkles")
+                    }
+                    .tag(Tabs.llm)
+            #endif
             AboutSettingsView()
                 .tabItem {
                     Label("About", systemImage: "info")

--- a/TRex/AppDelegate.swift
+++ b/TRex/AppDelegate.swift
@@ -8,6 +8,7 @@ import Sparkle
 
 // TesseractWrapper bridge removed - now using TesseractSwift directly in TRexCore
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     var menuBarItem: MenubarItem?
     var trex = TRex.shared
@@ -15,7 +16,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     var cancellable: Set<AnyCancellable> = []
     var onboardingWindowController: NSWindowController?
     var historyWindowController: NSWindowController?
-    let bundleID = Bundle.main.bundleIdentifier!
+    let bundleID = Bundle.main.bundleIdentifier ?? "com.ameba.TRex"
     #if !MAC_APP_STORE
     var softwareUpdater: SPUUpdater!
     #endif
@@ -48,8 +49,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
         setupShortcuts()
 
-        // Initialize LLM if enabled
+        #if !MAC_APP_STORE
+        // The App Store target does not expose third-party LLM controls, so it
+        // must not activate settings persisted by a direct-download install.
         trex.initializeLLM()
+        #endif
 
         showOnboardingIfNeeded()
     }
@@ -177,6 +181,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         window.center()
 
         let controller = NSWindowController(window: window)
+        window.setFrameAutosaveName("CaptureHistoryWindow")
         controller.contentViewController = NSHostingController(
             rootView: CaptureHistoryView(store: trex.captureHistoryStore)
         )
@@ -202,7 +207,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         }
 
         let myWindow = NSWindow(
-            contentRect: .init(origin: .zero, size: CGSize(width: 900, height: 700)),
+            contentRect: .init(origin: .zero, size: CGSize(width: 1000, height: 800)),
             styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/docs/release-notes/v2.0.1-beta.1.md
+++ b/docs/release-notes/v2.0.1-beta.1.md
@@ -1,0 +1,28 @@
+# TRex v2.0.1 Beta 1 Release Notes
+
+This beta focuses on update reliability, OCR correctness, and safer handling of captured content.
+
+## Improvements
+
+- Production releases are now also published to the beta update feed, so users on the beta train continue receiving the newest eligible build.
+- OCR engine routing, automatic language detection, custom words, and fallback behavior are more consistent across Vision, Tesseract, and LLM providers.
+- LLM requests now use fresh sessions for each capture, validate custom endpoints, enforce image-size limits, and support Apple Foundation Models on macOS 26.
+- Table output handles uneven rows, escaped Markdown, and embedded line breaks in CSV and TSV more reliably.
+- App Store builds now normalize embedded frameworks and exclude unavailable third-party LLM controls and initialization.
+- Onboarding, settings, capture history, menu behavior, accessibility labels, and drag-and-drop feedback have been refined for macOS.
+
+## Fixes
+
+- Fixed Unicode text before a URL causing incorrect URL detection ranges.
+- Fixed empty Vision results clearing the clipboard or capture history.
+- Fixed OCR timeouts waiting indefinitely for operations that ignored cancellation.
+- Fixed concurrent Tesseract requests racing through the shared engine.
+- Fixed watch mode repeatedly processing blank captures and accepting unsafe output paths.
+- Fixed temporary-file collisions and incomplete cleanup in the CLI, Shortcuts, and CLI installer.
+- Fixed the CLI installer accepting invalid downloads and preserving stale executable permissions.
+- Fixed release signing and notarization cleanup paths that could leave sensitive temporary files behind.
+- Fixed screen-coordinate conversion on displays with different scale factors.
+
+## Testing
+
+- Added regression coverage for OCR engine replacement, Unicode URL detection, watch-mode paths, table formatting, timeouts, LLM session isolation, endpoint validation, and image preprocessing.


### PR DESCRIPTION
## What changed

- Ensured production releases also update the beta appcast and added feed-order validation.
- Fixed OCR routing, concurrency, timeouts, Unicode URL detection, table formatting, and watch-mode behavior.
- Isolated LLM requests per capture, tightened endpoint and image validation, and corrected App Store feature gating.
- Hardened signing, notarization, temporary files, CLI installation, and embedded-framework packaging.
- Fixed onboarding, settings, accessibility, history-window, menu, drag-and-drop, and display-coordinate behavior.
- Added release notes for `v2.0.1-beta.1` and regression tests for the corrected paths.

## Why

Beta subscribers could be left on an older build after a production release because Sparkle compares build numbers and the feeds could diverge. The project sweep also found reliability and privacy defects across OCR, LLM, watch mode, packaging, and macOS UI flows.

## User impact

Beta users continue receiving the newest eligible production or beta build. Captures no longer clear output on empty recognition, OCR fallbacks are deterministic, LLM sessions do not retain prior capture context, and packaging and installer paths fail safely.

## Validation

- TRexCore: 13 tests passed.
- TRexLLM: 40 tests executed; 32 passed and 8 credential-gated live-provider tests skipped.
- Direct app Xcode analysis passed.
- App Store Release build passed, including framework normalization.
- CLI build and `--help` smoke test passed.
- Workflow YAML, shell scripts, appcast XML, feed ordering, and `git diff --check` passed.
- Final Codex review found no actionable regressions.

## Release

After merge, tag `v2.0.1-beta.1` to publish the beta.
