### PR TITLE
fix: recover empty OCR results with Tesseract

### DIFF
--- a/Packages/TRexCore/Sources/TRexCore/LanguageManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/LanguageManager.swift
@@ -47,6 +47,7 @@ public class LanguageManager {
 
         // Get downloaded Tesseract languages
         let downloadedTesseractLanguages = Set(tesseractEngine.availableLanguages())
+        let availableTesseractLanguages = Set(LanguageDownloader.allAvailableLanguages().map(\.code))
 
         // Add Vision languages
         for rawCode in visionLanguageCodes {
@@ -69,13 +70,14 @@ public class LanguageManager {
             let flagEmoji = getFlagEmoji(for: code)
             let tesseractCode = LanguageCodeMapper.toTesseract(code)
             let isDownloaded = downloadedTesseractLanguages.contains(tesseractCode)
+            let isAvailableInTesseract = availableTesseractLanguages.contains(tesseractCode)
 
             languages.append(Language(
                 code: code,
                 displayName: displayName,
                 flagEmoji: flagEmoji,
-                source: isDownloaded ? .both : .vision,
-                isDownloaded: true,
+                source: isAvailableInTesseract ? .both : .vision,
+                isDownloaded: isDownloaded,
                 fileSize: nil
             ))
             addedCodes.insert(code)

--- a/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
@@ -324,7 +324,12 @@ public class TRex: NSObject {
         currentInvocationMode = mode
 
         guard let ocrResult = await getText(imagePath) else { return }
-        guard var text = await recognizeAndProcessOCR(from: ocrResult) else { return }
+        guard var text = await recognizeAndProcessOCR(from: ocrResult),
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            logger.warning("⚠️ OCR returned no text; preserving the existing clipboard contents")
+            return
+        }
 
         // Apply LLM post-processing if enabled (runs after table detection)
         if preferences.llmEnablePostProcessing, let postProcessor = llmPostProcessor {
@@ -570,7 +575,8 @@ public class TRex: NSObject {
         // If automatic detection is enabled and we're not using Tesseract, use Vision directly
         if preferences.automaticLanguageDetection && !useTesseract && ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 13 {
             logger.info("🛤️ OCR Path: Vision with AUTOMATIC language detection")
-            return await performVisionOCR(cgImage: cgImage)
+            let result = await performVisionOCR(cgImage: cgImage)
+            return await recoverEmptyOCRResult(result, cgImage: cgImage, languages: languages, attemptedEngineID: "vision")
         }
 
         // If LLM OCR is enabled and available, use it
@@ -580,27 +586,76 @@ public class TRex: NSObject {
             processingState.set(true)
             let result = await performOCR(with: llmEngine, cgImage: cgImage, languages: languages)
             processingState.set(false)
-            return result
+            return await recoverEmptyOCRResult(result, cgImage: cgImage, languages: languages, attemptedEngineID: llmEngine.identifier)
         }
 
         // If Tesseract is disabled, only use Vision
         if !useTesseract {
             logger.info("🛤️ OCR Path: Using Apple Vision (Tesseract disabled)")
             if let visionEngine = OCRManager.shared.engines.first(where: { $0.identifier == "vision" }) {
-                return await performOCR(with: visionEngine, cgImage: cgImage, languages: languages)
+                let result = await performOCR(with: visionEngine, cgImage: cgImage, languages: languages)
+                return await recoverEmptyOCRResult(result, cgImage: cgImage, languages: languages, attemptedEngineID: visionEngine.identifier)
             } else {
                 logger.warning("⚠️ Vision engine not found, falling back to legacy path")
-                return await performVisionOCR(cgImage: cgImage)
+                let result = await performVisionOCR(cgImage: cgImage)
+                return await recoverEmptyOCRResult(result, cgImage: cgImage, languages: languages, attemptedEngineID: "vision")
             }
         }
 
         if let engine = OCRManager.shared.findEngine(for: languages) {
             logger.info("🛤️ OCR Path: Using \(engine.name, privacy: .public) engine with explicit languages")
-            return await performOCR(with: engine, cgImage: cgImage, languages: languages)
+            let result = await performOCR(with: engine, cgImage: cgImage, languages: languages)
+            return await recoverEmptyOCRResult(result, cgImage: cgImage, languages: languages, attemptedEngineID: engine.identifier)
         } else {
             logger.warning("🛤️ OCR Path: No suitable OCR engine found for languages, falling back to Vision")
-            return await performVisionOCR(cgImage: cgImage)
+            let result = await performVisionOCR(cgImage: cgImage)
+            return await recoverEmptyOCRResult(result, cgImage: cgImage, languages: languages, attemptedEngineID: "vision")
         }
+    }
+
+    /// Vision can complete successfully with zero observations on newer macOS releases.
+    /// Do not let that erase the user's clipboard; retry with the bundled Tesseract engine.
+    private func recoverEmptyOCRResult(
+        _ result: OCRResult?,
+        cgImage: CGImage,
+        languages: [String],
+        attemptedEngineID: String
+    ) async -> OCRResult? {
+        if let result, !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return result
+        }
+
+        guard Self.shouldAttemptTesseractFallback(
+            attemptedEngineID: attemptedEngineID,
+            tesseractEnabled: preferences.tesseractEnabled
+        ),
+              let tesseractEngine = OCRManager.shared.engines.first(where: { $0.identifier == "tesseract" })
+        else {
+            logger.warning("⚠️ OCR returned no text and no alternate engine is available")
+            return nil
+        }
+
+        let fallbackLanguages = languages.isEmpty
+            ? [LanguageCodeMapper.standardize(preferences.recognitionLanguageCode)]
+            : languages
+        logger.warning("⚠️ \(attemptedEngineID, privacy: .public) returned no text; retrying with Tesseract")
+        let fallback = await performOCR(with: tesseractEngine, cgImage: cgImage, languages: fallbackLanguages)
+
+        guard let fallback,
+              !fallback.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            logger.warning("⚠️ Tesseract fallback also returned no text")
+            return nil
+        }
+
+        return fallback
+    }
+
+    nonisolated static func shouldAttemptTesseractFallback(
+        attemptedEngineID: String,
+        tesseractEnabled: Bool
+    ) -> Bool {
+        tesseractEnabled && attemptedEngineID != "tesseract"
     }
     
     
@@ -675,6 +730,11 @@ public class TRex: NSObject {
 
     @MainActor
     func processDetectedText(_ text: String, ocrResult: OCRResult? = nil) {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            logger.warning("⚠️ Refusing to replace the clipboard with empty OCR output")
+            return
+        }
+
         showNotification(text: text)
 
         // Save to capture history (GUI only)

--- a/Packages/TRexCore/Sources/TRexCore/TesseractOCREngine.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TesseractOCREngine.swift
@@ -104,8 +104,32 @@ public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
     }
 }
 
-private extension TesseractOCREngine {
-    func recognizeSynchronously(
+extension TesseractOCREngine {
+    /// TesseractSwift can return an empty result for grayscale TIFF images read from
+    /// NSPasteboard. Render every input into a standard 8-bit RGBA bitmap first.
+    nonisolated static func makeTesseractCompatibleImage(from image: CGImage) throws -> CGImage {
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: image.width,
+            height: image.height,
+            bitsPerComponent: 8,
+            bytesPerRow: image.width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: bitmapInfo
+        ) else {
+            throw OCRError.imageProcessingFailed("Unable to create an RGBA bitmap for Tesseract")
+        }
+
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        guard let normalizedImage = context.makeImage() else {
+            throw OCRError.imageProcessingFailed("Unable to render an RGBA bitmap for Tesseract")
+        }
+        return normalizedImage
+    }
+
+    private func recognizeSynchronously(
         image: CGImage,
         requestedLanguages: [String],
         tesseractCodes: [String],
@@ -122,7 +146,8 @@ private extension TesseractOCREngine {
         defer { tesseractEngine.clear() }
 
         tesseractEngine.setPageSegmentationMode(recognitionLevel == .accurate ? .auto : .sparseText)
-        let text = try tesseractEngine.recognize(cgImage: image)
+        let normalizedImage = try Self.makeTesseractCompatibleImage(from: image)
+        let text = try tesseractEngine.recognize(cgImage: normalizedImage)
         let confidence = Float(tesseractEngine.confidence()) / 100.0
 
         return OCRResult(
@@ -134,7 +159,7 @@ private extension TesseractOCREngine {
         )
     }
 
-    func languageFileURL(forTesseractCode code: String) -> URL {
+    private func languageFileURL(forTesseractCode code: String) -> URL {
         tessdataPath.appendingPathComponent("\(code).traineddata")
     }
 }

--- a/Packages/TRexCore/Tests/TRexCoreTests/LanguageManagerTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/LanguageManagerTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import TRexCore
+
+final class LanguageManagerTests: XCTestCase {
+    func testEnglishRemainsAvailableForTesseractDownload() {
+        let languages = LanguageManager.shared.availableLanguages()
+        let english = languages.first { $0.displayName == "English" }
+
+        XCTAssertNotNil(english)
+        guard let english else { return }
+        XCTAssertNotEqual(english.source, .vision)
+    }
+}

--- a/Packages/TRexCore/Tests/TRexCoreTests/TesseractOCREngineTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/TesseractOCREngineTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Vision
+import XCTest
+@testable import TRexCore
+
+final class TesseractOCREngineTests: XCTestCase {
+    private func makeGrayscaleImage(with text: String) -> CGImage {
+        let width = 1_400
+        let height = 320
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        )!
+        context.setFillColor(gray: 1, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        let graphicsContext = NSGraphicsContext(cgContext: context, flipped: false)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = graphicsContext
+        (text as NSString).draw(
+            at: NSPoint(x: 80, y: 120),
+            withAttributes: [
+                .font: NSFont.systemFont(ofSize: 56),
+                .foregroundColor: NSColor.black,
+            ]
+        )
+        NSGraphicsContext.restoreGraphicsState()
+        return context.makeImage()!
+    }
+
+    func testNormalizesGrayscaleInputToRGBAWithoutLanguageData() throws {
+        let grayscale = makeGrayscaleImage(with: "TRex grayscale normalization")
+        let normalized = try TesseractOCREngine.makeTesseractCompatibleImage(from: grayscale)
+
+        XCTAssertEqual(normalized.width, grayscale.width)
+        XCTAssertEqual(normalized.height, grayscale.height)
+        XCTAssertEqual(normalized.bitsPerPixel, 32)
+        XCTAssertEqual(normalized.colorSpace?.model, .rgb)
+    }
+
+    func testFallbackRespectsTesseractPreferenceAndDoesNotReenter() {
+        XCTAssertFalse(
+            TRex.shouldAttemptTesseractFallback(
+                attemptedEngineID: "vision",
+                tesseractEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            TRex.shouldAttemptTesseractFallback(
+                attemptedEngineID: "tesseract",
+                tesseractEnabled: true
+            )
+        )
+        XCTAssertTrue(
+            TRex.shouldAttemptTesseractFallback(
+                attemptedEngineID: "vision",
+                tesseractEnabled: true
+            )
+        )
+    }
+
+    func testRecognizesGrayscaleImageWhenLanguageDataIsInstalled() async throws {
+        let tessdata = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/TRex/tessdata/eng.traineddata")
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: tessdata.path),
+            "English Tesseract data is not installed"
+        )
+
+        let result = try await TesseractOCREngine().recognizeText(
+            in: makeGrayscaleImage(with: "TRex grayscale clipboard test"),
+            languages: ["en-US"],
+            recognitionLevel: .accurate
+        )
+
+        XCTAssertTrue(result.text.localizedCaseInsensitiveContains("grayscale"))
+    }
+}


### PR DESCRIPTION
## Summary

- preserve clipboard output when OCR produces only whitespace
- retry empty Vision or LLM results with Tesseract when Tesseract is enabled
- normalize grayscale input to RGBA before Tesseract recognition
- distinguish downloadable Tesseract languages from installed language data

## Safety

The fallback respects the Tesseract preference and never re-enters Tesseract after a Tesseract attempt. Disabled Tesseract cannot trigger language downloads.

## Verification

- TRexCore: 17 tests passed
- deterministic grayscale-to-RGBA and fallback-policy tests
- installed-language grayscale OCR integration test
- Xcode Debug build succeeded with code signing disabled