### PR TITLE
fix: restore clipboard after failed text writes

### DIFF
--- a/Packages/TRexCore/Sources/TRexCore/PasteboardWriter.swift
+++ b/Packages/TRexCore/Sources/TRexCore/PasteboardWriter.swift
@@ -1,0 +1,47 @@
+import AppKit
+
+/// Attempts to replace pasteboard text. Before clearing, it eagerly snapshots
+/// readable representations and, if writing fails, attempts a best-effort restore.
+/// The return value reports only whether replacement succeeded; it does not
+/// guarantee that every prior representation was restored.
+@MainActor
+public enum PasteboardWriter {
+    @discardableResult
+    public static func replaceString(_ text: String, in pasteboard: NSPasteboard = .general) -> Bool {
+        replaceString(text, in: pasteboard) { value, board in
+            board.setString(value, forType: .string)
+        }
+    }
+
+    @discardableResult
+    static func replaceString(
+        _ text: String,
+        in pasteboard: NSPasteboard,
+        writer: (String, NSPasteboard) -> Bool
+    ) -> Bool {
+        let previousItems = copiedItems(from: pasteboard)
+        pasteboard.clearContents()
+
+        guard writer(text, pasteboard) else {
+            if !previousItems.isEmpty {
+                _ = pasteboard.writeObjects(previousItems)
+            }
+            return false
+        }
+
+        return true
+    }
+
+    private static func copiedItems(from pasteboard: NSPasteboard) -> [NSPasteboardItem] {
+        (pasteboard.pasteboardItems ?? []).compactMap { item in
+            let copy = NSPasteboardItem()
+            var copiedRepresentation = false
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copiedRepresentation = copy.setData(data, forType: type) || copiedRepresentation
+                }
+            }
+            return copiedRepresentation ? copy : nil
+        }
+    }
+}

--- a/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
@@ -689,8 +689,10 @@ public class TRex: NSObject {
         // Choose between automation and clipboard
         guard invocationRequiresAutomation, hasAutomationsConfigured else {
             let pasteBoard = NSPasteboard.general
-            pasteBoard.clearContents()
-            pasteBoard.setString(text, forType: .string)
+            guard PasteboardWriter.replaceString(text, in: pasteBoard) else {
+                logger.error("❌ Failed to write OCR text to the clipboard")
+                return
+            }
             // output to STDOUT for CLI
             if BundleIdentifiers.isCLI {
                 print(text)

--- a/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/WatchModeManager.swift
@@ -294,19 +294,23 @@ public final class WatchModeManager: ObservableObject {
     }
 
     private func appendToClipboard(_ text: String) -> Bool {
+        guard let combined = Self.combinedClipboardText(existing: clipboardAccumulator, next: text) else {
+            logger.warning("Ignoring empty watch-mode OCR output")
+            return false
+        }
+
         let pasteboard = NSPasteboard.general
-        let combined: String
-        if clipboardAccumulator.isEmpty {
-            combined = text
-        } else {
-            combined = clipboardAccumulator + "\n---\n" + text
+        guard PasteboardWriter.replaceString(combined, in: pasteboard) else {
+            logger.error("Failed to write watch-mode output to clipboard")
+            return false
         }
-        pasteboard.clearContents()
-        if pasteboard.setString(combined, forType: .string) {
-            clipboardAccumulator = combined
-            return true
-        }
-        return false
+        clipboardAccumulator = combined
+        return true
+    }
+
+    nonisolated static func combinedClipboardText(existing: String, next: String) -> String? {
+        guard !next.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return existing.isEmpty ? next : existing + "\n---\n" + next
     }
 
     private func resetClipboardAccumulator() {

--- a/Packages/TRexCore/Tests/TRexCoreTests/PasteboardWriterTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/PasteboardWriterTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import TRexCore
+
+@MainActor
+final class PasteboardWriterTests: XCTestCase {
+    func testReplacesTextOnAnIsolatedPasteboard() {
+        let pasteboard = NSPasteboard(name: .init("TRexCoreTests.\(UUID().uuidString)"))
+        XCTAssertTrue(pasteboard.setString("before", forType: .string))
+
+        XCTAssertTrue(PasteboardWriter.replaceString("after", in: pasteboard))
+        XCTAssertEqual(pasteboard.string(forType: .string), "after")
+    }
+
+    func testRestoresPreviousPayloadWhenWriteFails() {
+        let pasteboard = NSPasteboard(name: .init("TRexCoreTests.\(UUID().uuidString)"))
+        XCTAssertTrue(pasteboard.setString("before", forType: .string))
+
+        let success = PasteboardWriter.replaceString("after", in: pasteboard) { _, _ in false }
+
+        XCTAssertFalse(success)
+        XCTAssertEqual(pasteboard.string(forType: .string), "before")
+    }
+}

--- a/Packages/TRexCore/Tests/TRexCoreTests/WatchModeManagerTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/WatchModeManagerTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import TRexCore
+
+final class WatchModeManagerTests: XCTestCase {
+    func testClipboardOutputCombinesNonEmptyCaptures() {
+        XCTAssertEqual(WatchModeManager.combinedClipboardText(existing: "", next: "first"), "first")
+        XCTAssertEqual(
+            WatchModeManager.combinedClipboardText(existing: "first", next: "second"),
+            "first\n---\nsecond"
+        )
+    }
+
+    func testClipboardOutputRejectsWhitespaceOnlyCapture() {
+        XCTAssertNil(WatchModeManager.combinedClipboardText(existing: "first", next: " \n\t "))
+    }
+}

--- a/TRex/App/UI/History/CaptureHistoryDetailView.swift
+++ b/TRex/App/UI/History/CaptureHistoryDetailView.swift
@@ -52,9 +52,7 @@ struct CaptureHistoryDetailView: View {
             // Actions
             HStack {
                 Button {
-                    let pasteboard = NSPasteboard.general
-                    pasteboard.clearContents()
-                    pasteboard.setString(entry.text, forType: .string)
+                    _ = PasteboardWriter.replaceString(entry.text)
                 } label: {
                     Label("Copy to Clipboard", systemImage: "doc.on.doc")
                 }

--- a/TRex/App/UI/MenuBarItem.swift
+++ b/TRex/App/UI/MenuBarItem.swift
@@ -222,11 +222,9 @@ class MenubarItem: NSObject {
         NSWorkspace.shared.open(url)
     }
 
-    @objc func copyHistoryEntry(_ sender: NSMenuItem) {
+    @MainActor @objc func copyHistoryEntry(_ sender: NSMenuItem) {
         if let text = sender.representedObject as? String {
-            let pasteboard = NSPasteboard.general
-            pasteboard.clearContents()
-            pasteboard.setString(text, forType: .string)
+            _ = PasteboardWriter.replaceString(text)
         }
     }
 


### PR DESCRIPTION
## Summary

- centralize plain-text pasteboard replacement
- eagerly snapshot readable pasteboard representations before clearing
- attempt best-effort restoration when the replacement write fails
- apply the safe writer to OCR capture, watch mode, and history copy actions
- reject whitespace-only watch-mode output without advancing its accumulator

## Semantics

The return value reports whether replacement succeeded. Restoration is explicitly best-effort and does not claim that unreadable or lazy representations can always be recovered.

## Verification

- TRexCore: 17 tests passed
- isolated pasteboard success and injected-failure restoration tests
- watch-mode combination and whitespace tests
- Xcode Debug build succeeded with code signing disabled