### PR TITLE
fix: ignore empty automation and history inputs

### DIFF
--- a/Packages/TRexCore/Sources/TRexCore/CaptureHistoryStore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/CaptureHistoryStore.swift
@@ -45,8 +45,10 @@ public final class CaptureHistoryStore: ObservableObject {
     private let historyFileURL: URL
     private var saveTask: Task<Void, Never>?
 
-    public init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    /// - Parameter storageRoot: Optional Application Support root used for persistence.
+    ///   Tests can supply an isolated temporary root to avoid touching user history.
+    public init(storageRoot: URL? = nil) {
+        let appSupport = storageRoot ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let historyDir = appSupport.appendingPathComponent("TRex/History", isDirectory: true)
         self.historyDirectoryURL = historyDir
         self.thumbnailsDirectoryURL = historyDir.appendingPathComponent("thumbnails", isDirectory: true)
@@ -60,6 +62,11 @@ public final class CaptureHistoryStore: ObservableObject {
 
     /// Add a new history entry from captured text and an optional OCR result.
     public func addEntry(text: String, ocrResult: OCRResult? = nil, maxEntries: Int = 100) {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            logger.warning("Ignoring empty capture-history entry")
+            return
+        }
+
         let maxEntries = max(1, maxEntries)
         let entryID = UUID()
         var thumbnailFilename: String?
@@ -110,6 +117,11 @@ public final class CaptureHistoryStore: ObservableObject {
             }
         }
         saveAsync()
+    }
+
+    /// Await the currently queued persistence write. Internal for deterministic tests.
+    func waitForPendingSave() async {
+        await saveTask?.value
     }
 
     /// Resolve the file URL for an entry's thumbnail.

--- a/Packages/TRexCore/Sources/TRexCore/ShortcutsManager.swift
+++ b/Packages/TRexCore/Sources/TRexCore/ShortcutsManager.swift
@@ -66,8 +66,7 @@ public class ShortcutsManager: ObservableObject {
     }
 
     public func runShortcut(inputText: String) {
-        let shortcut = currentShortcut
-        guard !shortcut.isEmpty else { return }
+        guard let shortcut = Self.normalizedShortcutName(currentShortcut) else { return }
         guard isShortcutsAvailable() else { return }
         let inputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("trex-shortcut-\(UUID().uuidString).txt")
@@ -94,6 +93,11 @@ public class ShortcutsManager: ObservableObject {
 
             process.waitUntilExit()
         }
+    }
+
+    nonisolated static func normalizedShortcutName(_ name: String) -> String? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     public func viewCurrentShortcut() {

--- a/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
@@ -121,14 +121,37 @@ public class TRex: NSObject {
     }
 
     var hasAutomationsConfigured: Bool {
-        !preferences.autoOpenProvidedURL.isEmpty || !preferences.autoRunShortcut.isEmpty
+        Self.hasConfiguredAutomation(
+            autoOpenProvidedURL: preferences.autoOpenProvidedURL,
+            autoRunShortcut: preferences.autoRunShortcut
+        )
     }
 
     var invocationRequiresAutomation: Bool {
-        currentInvocationMode == .captureClipboardAndTriggerAutomation ||
-            currentInvocationMode == .captureScreenAndTriggerAutomation ||
-            currentInvocationMode == .captureFromFileAndTriggerAutomation ||
-            currentInvocationMode == .captureMultiRegionAndTriggerAutomation
+        Self.invocationRequiresAutomation(currentInvocationMode)
+    }
+
+    nonisolated static func hasConfiguredAutomation(autoOpenProvidedURL: String, autoRunShortcut: String) -> Bool {
+        !autoOpenProvidedURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            !autoRunShortcut.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    nonisolated static func invocationRequiresAutomation(_ mode: InvocationMode) -> Bool {
+        mode == .captureClipboardAndTriggerAutomation ||
+            mode == .captureScreenAndTriggerAutomation ||
+            mode == .captureFromFileAndTriggerAutomation ||
+            mode == .captureMultiRegionAndTriggerAutomation
+    }
+
+    nonisolated static func shouldRouteToAutomation(
+        mode: InvocationMode,
+        autoOpenProvidedURL: String,
+        autoRunShortcut: String
+    ) -> Bool {
+        invocationRequiresAutomation(mode) && hasConfiguredAutomation(
+            autoOpenProvidedURL: autoOpenProvidedURL,
+            autoRunShortcut: autoRunShortcut
+        )
     }
 
     // MARK: - LLM Integration
@@ -687,7 +710,11 @@ public class TRex: NSObject {
         }
 
         // Choose between automation and clipboard
-        guard invocationRequiresAutomation, hasAutomationsConfigured else {
+        guard Self.shouldRouteToAutomation(
+            mode: currentInvocationMode,
+            autoOpenProvidedURL: preferences.autoOpenProvidedURL,
+            autoRunShortcut: preferences.autoRunShortcut
+        ) else {
             let pasteBoard = NSPasteboard.general
             pasteBoard.clearContents()
             pasteBoard.setString(text, forType: .string)

--- a/Packages/TRexCore/Tests/TRexCoreTests/AutomationRoutingTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/AutomationRoutingTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import TRexCore
+
+final class AutomationRoutingTests: XCTestCase {
+    func testNormalCaptureAlwaysKeepsClipboardRoute() {
+        XCTAssertFalse(
+            TRex.shouldRouteToAutomation(
+                mode: .captureScreen,
+                autoOpenProvidedURL: "https://example.com/?text={text}",
+                autoRunShortcut: "Process OCR"
+            )
+        )
+    }
+
+    func testAutomationCaptureNeedsMeaningfulConfiguration() {
+        XCTAssertFalse(
+            TRex.shouldRouteToAutomation(
+                mode: .captureScreenAndTriggerAutomation,
+                autoOpenProvidedURL: " \n",
+                autoRunShortcut: "\t"
+            )
+        )
+        XCTAssertTrue(
+            TRex.shouldRouteToAutomation(
+                mode: .captureScreenAndTriggerAutomation,
+                autoOpenProvidedURL: "",
+                autoRunShortcut: "Process OCR"
+            )
+        )
+        XCTAssertTrue(
+            TRex.shouldRouteToAutomation(
+                mode: .captureClipboardAndTriggerAutomation,
+                autoOpenProvidedURL: "https://example.com/?text={text}",
+                autoRunShortcut: ""
+            )
+        )
+    }
+}

--- a/Packages/TRexCore/Tests/TRexCoreTests/CaptureHistoryStoreTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/CaptureHistoryStoreTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import TRexCore
+
+@MainActor
+final class CaptureHistoryStoreTests: XCTestCase {
+    func testIgnoresEmptyEntriesAndPersistsPrunedSnapshot() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TRexHistoryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = CaptureHistoryStore(storageRoot: root)
+        store.addEntry(text: " \n\t ")
+        XCTAssertTrue(store.entries.isEmpty)
+
+        store.addEntry(text: "first", maxEntries: 1)
+        store.addEntry(text: "second", maxEntries: 1)
+        XCTAssertEqual(store.entries.map(\.text), ["second"])
+
+        await store.waitForPendingSave()
+        let historyURL = root.appendingPathComponent("TRex/History/history.json")
+        let data = try Data(contentsOf: historyURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let persisted = try decoder.decode([CaptureHistoryEntry].self, from: data)
+        XCTAssertEqual(persisted.map(\.text), ["second"])
+    }
+}

--- a/Packages/TRexCore/Tests/TRexCoreTests/ShortcutsManagerTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/ShortcutsManagerTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import TRexCore
+
+final class ShortcutsManagerTests: XCTestCase {
+    func testShortcutNameMustBeMeaningfulAndIsTrimmed() {
+        XCTAssertNil(ShortcutsManager.normalizedShortcutName(" \n\t "))
+        XCTAssertEqual(ShortcutsManager.normalizedShortcutName("  Process OCR \n"), "Process OCR")
+    }
+}


### PR DESCRIPTION
## Summary

- require meaningful automation configuration before diverting output from the clipboard
- trim Shortcut names and ignore whitespace-only values
- reject whitespace-only capture-history entries
- add an isolated history storage root and deterministic persistence flush seam for tests

## Verification

- TRexCore: 17 tests passed
- automation routing tests cover normal and automation invocation modes
- history test awaits persistence and reads back the pruned JSON snapshot
- Shortcut normalization tests cover whitespace and trimmed names
- Xcode Debug build succeeded with code signing disabled