### PR TITLE
fix: keep OCR captures responsive

### DIFF
--- a/Packages/TRexCore/Sources/TRexCore/Preferences.swift
+++ b/Packages/TRexCore/Sources/TRexCore/Preferences.swift
@@ -446,7 +446,7 @@ public class Preferences: ObservableObject {
         captureHistoryEnabled = Preferences.getValue(key: .CaptureHistoryEnabled) as? Bool ?? true
         let storedMaxEntries = Preferences.getValue(key: .CaptureHistoryMaxEntries) as? Int ?? 100
         captureHistoryMaxEntries = Self.clampHistoryEntries(storedMaxEntries)
-        tableDetectionEnabled = Preferences.getValue(key: .TableDetectionEnabled) as? Bool ?? true
+        tableDetectionEnabled = Preferences.getValue(key: .TableDetectionEnabled) as? Bool ?? false
         if let rawFormat = Preferences.getValue(key: .TableOutputFormat) as? String,
            let format = TableOutputFormat(rawValue: rawFormat) {
             tableOutputFormat = format

--- a/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TRexCore.swift
@@ -77,6 +77,21 @@ private final class ContinuationRace<Value: Sendable>: @unchecked Sendable {
     }
 }
 
+@MainActor
+final class SingleFlightGate {
+    private var isActive = false
+
+    func begin() -> Bool {
+        guard !isActive else { return false }
+        isActive = true
+        return true
+    }
+
+    func end() {
+        isActive = false
+    }
+}
+
 /// Observable state for LLM processing activity, used to drive menu bar animations.
 /// All access is confined to the main actor to ensure thread-safe UI updates.
 @MainActor
@@ -98,6 +113,7 @@ public class TRex: NSObject {
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.ameba.TRex", category: "TRexCore")
     private var llmEngine: LLMOCREngine?
     private var llmPostProcessor: LLMPostProcessor?
+    private let visionTableDetectionGate = SingleFlightGate()
     public let llmProcessingState = LLMProcessingState()
     public let captureHistoryStore = CaptureHistoryStore()
     public let watchModeManager = WatchModeManager()
@@ -235,17 +251,34 @@ public class TRex: NSObject {
         {text}
         """
 
-    /// Detect tables in the captured content and format them.
+    private static let tableDetectionTimeout: TimeInterval = 3
+
     /// Detect tables in the captured content and format them.
     /// Returns combined text with formatted tables, or nil if no tables were detected.
     /// Tries Vision document recognition first (macOS 26+), then falls back to LLM.
     private func detectAndFormatTables(ocrText: String, capturedImage: CGImage?) async -> String? {
         let format = preferences.tableOutputFormat
 
-        if #available(macOS 26, *),
-           let cgImage = capturedImage,
-           let visionResult = await detectTablesViaVision(in: cgImage, format: format) {
-            return visionResult
+        if #available(macOS 26, *), let cgImage = capturedImage {
+            guard visionTableDetectionGate.begin() else {
+                logger.warning("⏭️ Table detection is still finishing a previous request; using the original OCR text")
+                return nil
+            }
+
+            do {
+                let visionResult = try await withTimeout(seconds: Self.tableDetectionTimeout) {
+                    await self.runVisionTableDetection(in: cgImage, format: format)
+                }
+                if let visionResult {
+                    return visionResult
+                }
+            } catch TimeoutError.timedOut {
+                logger.warning("⏱️ Table detection timed out; using the original OCR text")
+                return nil
+            } catch {
+                logger.warning("⚠️ Table detection failed: \(error.localizedDescription, privacy: .public); using the original OCR text")
+                return nil
+            }
         }
 
         // Fall back to the configured post-processor when Vision is unavailable,
@@ -255,6 +288,12 @@ public class TRex: NSObject {
         }
 
         return nil
+    }
+
+    @available(macOS 26, *)
+    private func runVisionTableDetection(in cgImage: CGImage, format: TableOutputFormat) async -> String? {
+        defer { visionTableDetectionGate.end() }
+        return await detectTablesViaVision(in: cgImage, format: format)
     }
 
     /// Use Vision's RecognizeDocumentsRequest (macOS 26+) for structural table detection.

--- a/Packages/TRexCore/Sources/TRexCore/TesseractOCREngine.swift
+++ b/Packages/TRexCore/Sources/TRexCore/TesseractOCREngine.swift
@@ -5,8 +5,7 @@ import Vision
 
 public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
     private let tessdataPath: URL
-    private let tesseractEngine: TesseractEngine
-    private let recognitionLock = NSLock()
+    private let engineCoordinator: TesseractEngineCoordinator
     private let languageDownloader = LanguageDownloader.shared
     
     public init() {
@@ -20,7 +19,7 @@ public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
         try? FileManager.default.createDirectory(at: tessdataPath, withIntermediateDirectories: true)
         
         // Initialize Tesseract engine
-        self.tesseractEngine = TesseractEngine(dataPath: tessdataPath.path)
+        self.engineCoordinator = TesseractEngineCoordinator(dataPath: tessdataPath.path)
     }
     
     public var name: String { "Tesseract OCR" }
@@ -62,11 +61,18 @@ public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
             }
         }
 
-        return try recognizeSynchronously(
+        let recognition = try await engineCoordinator.recognize(
             image: image,
-            requestedLanguages: requestedLanguages,
-            tesseractCodes: tesseractCodes,
+            language: tesseractCodes.joined(separator: "+"),
             recognitionLevel: recognitionLevel
+        )
+
+        return OCRResult(
+            text: recognition.text,
+            confidence: recognition.confidence,
+            recognizedLanguages: requestedLanguages,
+            engineName: "Tesseract",
+            recognitionLevel: recognitionLevel == .accurate ? "accurate" : "fast"
         )
     }
     
@@ -104,36 +110,65 @@ public final class TesseractOCREngine: @unchecked Sendable, OCREngine {
     }
 }
 
-private extension TesseractOCREngine {
-    func recognizeSynchronously(
-        image: CGImage,
-        requestedLanguages: [String],
-        tesseractCodes: [String],
-        recognitionLevel: VNRequestTextRecognitionLevel
-    ) throws -> OCRResult {
-        // TesseractEngine is stateful. Serializing initialization, recognition,
-        // confidence reads, and cleanup prevents overlapping captures from
-        // corrupting its native state.
-        recognitionLock.lock()
-        defer { recognitionLock.unlock() }
+protocol TesseractEngineAdapter: AnyObject {
+    func initialize(language: String) throws
+    func recognize(image: CGImage, recognitionLevel: VNRequestTextRecognitionLevel) throws -> (text: String, confidence: Float)
+    func clear()
+}
 
-        let initializationCode = tesseractCodes.joined(separator: "+")
-        try tesseractEngine.initialize(language: initializationCode)
-        defer { tesseractEngine.clear() }
+private final class NativeTesseractEngineAdapter: TesseractEngineAdapter {
+    private let engine: TesseractEngine
 
-        tesseractEngine.setPageSegmentationMode(recognitionLevel == .accurate ? .auto : .sparseText)
-        let text = try tesseractEngine.recognize(cgImage: image)
-        let confidence = Float(tesseractEngine.confidence()) / 100.0
-
-        return OCRResult(
-            text: text,
-            confidence: confidence,
-            recognizedLanguages: requestedLanguages,
-            engineName: "Tesseract",
-            recognitionLevel: recognitionLevel == .accurate ? "accurate" : "fast"
-        )
+    init(dataPath: String) {
+        engine = TesseractEngine(dataPath: dataPath)
     }
 
+    func initialize(language: String) throws {
+        try engine.initialize(language: language)
+    }
+
+    func recognize(
+        image: CGImage,
+        recognitionLevel: VNRequestTextRecognitionLevel
+    ) throws -> (text: String, confidence: Float) {
+        engine.setPageSegmentationMode(recognitionLevel == .accurate ? .auto : .sparseText)
+        let text = try engine.recognize(cgImage: image)
+        return (text, Float(engine.confidence()) / 100)
+    }
+
+    func clear() {
+        engine.clear()
+    }
+}
+
+actor TesseractEngineCoordinator {
+    private let engine: any TesseractEngineAdapter
+
+    init(dataPath: String) {
+        engine = NativeTesseractEngineAdapter(dataPath: dataPath)
+    }
+
+    init(engine: any TesseractEngineAdapter) {
+        self.engine = engine
+    }
+
+    func recognize(
+        image: CGImage,
+        language: String,
+        recognitionLevel: VNRequestTextRecognitionLevel
+    ) throws -> (text: String, confidence: Float) {
+        // Actor queuing suspends waiters instead of blocking threads on NSLock.
+        // Cancelled requests are discarded before they can touch native state.
+        try Task.checkCancellation()
+        try engine.initialize(language: language)
+        defer { engine.clear() }
+
+        try Task.checkCancellation()
+        return try engine.recognize(image: image, recognitionLevel: recognitionLevel)
+    }
+}
+
+private extension TesseractOCREngine {
     func languageFileURL(forTesseractCode code: String) -> URL {
         tessdataPath.appendingPathComponent("\(code).traineddata")
     }

--- a/Packages/TRexCore/Tests/TRexCoreTests/TableDetectionTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/TableDetectionTests.swift
@@ -3,6 +3,17 @@ import XCTest
 @testable import TRexCore
 
 final class TableDetectionTests: XCTestCase {
+    @MainActor
+    func testSingleFlightGateRejectsOverlapUntilCurrentWorkEnds() {
+        let gate = SingleFlightGate()
+
+        XCTAssertTrue(gate.begin())
+        XCTAssertFalse(gate.begin())
+
+        gate.end()
+        XCTAssertTrue(gate.begin())
+    }
+
     func testMarkdownEscapesPipesAndNormalizesUnevenRows() {
         let table = DetectedTable(
             headers: ["Name", "Status"],

--- a/Packages/TRexCore/Tests/TRexCoreTests/TesseractConcurrencyTests.swift
+++ b/Packages/TRexCore/Tests/TRexCoreTests/TesseractConcurrencyTests.swift
@@ -1,0 +1,97 @@
+import CoreGraphics
+import Foundation
+import Vision
+import XCTest
+
+@testable import TRexCore
+
+final class TesseractConcurrencyTests: XCTestCase {
+    func testCancelledWaiterNeverTouchesNativeEngine() async throws {
+        let firstRecognitionStarted = expectation(description: "first recognition started")
+        let releaseFirstRecognition = DispatchSemaphore(value: 0)
+        let engine = BlockingTesseractEngine(
+            onFirstRecognition: { firstRecognitionStarted.fulfill() },
+            releaseFirstRecognition: releaseFirstRecognition
+        )
+        let coordinator = TesseractEngineCoordinator(engine: engine)
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        let image = try XCTUnwrap(context.makeImage())
+
+        let first = Task {
+            try await coordinator.recognize(
+                image: image,
+                language: "eng",
+                recognitionLevel: .accurate
+            )
+        }
+        await fulfillment(of: [firstRecognitionStarted], timeout: 1)
+
+        let cancelledWaiter = Task {
+            try await coordinator.recognize(
+                image: image,
+                language: "ita",
+                recognitionLevel: .accurate
+            )
+        }
+        cancelledWaiter.cancel()
+        releaseFirstRecognition.signal()
+
+        _ = try await first.value
+
+        do {
+            _ = try await cancelledWaiter.value
+            XCTFail("Expected queued recognition to be cancelled")
+        } catch is CancellationError {
+            XCTAssertEqual(engine.initializedLanguages, ["eng"])
+        }
+    }
+}
+
+private final class BlockingTesseractEngine: TesseractEngineAdapter, @unchecked Sendable {
+    private let lock = NSLock()
+    private let onFirstRecognition: @Sendable () -> Void
+    private let releaseFirstRecognition: DispatchSemaphore
+    private var languages: [String] = []
+    private var recognitionCount = 0
+
+    init(
+        onFirstRecognition: @escaping @Sendable () -> Void,
+        releaseFirstRecognition: DispatchSemaphore
+    ) {
+        self.onFirstRecognition = onFirstRecognition
+        self.releaseFirstRecognition = releaseFirstRecognition
+    }
+
+    var initializedLanguages: [String] {
+        lock.withLock { languages }
+    }
+
+    func initialize(language: String) {
+        lock.withLock { languages.append(language) }
+    }
+
+    func recognize(
+        image: CGImage,
+        recognitionLevel: VNRequestTextRecognitionLevel
+    ) throws -> (text: String, confidence: Float) {
+        let isFirst = lock.withLock { () -> Bool in
+            recognitionCount += 1
+            return recognitionCount == 1
+        }
+        if isFirst {
+            onFirstRecognition()
+            releaseFirstRecognition.wait()
+        }
+        return ("ok", 1)
+    }
+
+    func clear() {}
+}


### PR DESCRIPTION
## Summary

- bound Vision table detection to three seconds and fall back to the original OCR text on timeout
- keep table detection single-flight until a late Vision request actually finishes
- make table detection opt-in by default for new installations
- serialize Tesseract native state through an actor so queued captures suspend instead of blocking threads
- discard cancelled Tesseract requests before they touch native state

## Motivation

On macOS 27, a live `RecognizeDocumentsRequest` took about 98 seconds after OCR had already completed. During that time the capture transaction stayed locked and every later shortcut was rejected as `Capture already in progress`, so the result appeared to never reach the clipboard.

The existing generic timeout returns promptly for non-cooperative work, but table detection was not using it. Tesseract also used a blocking `NSLock`, which allowed cancelled waiters to accumulate behind a stuck native recognition.

## Verification

- TRexCore: 15 tests passed, 0 failures
- deterministic concurrency test holds the first Tesseract recognition, cancels a queued second request, and verifies the cancelled request never initializes native state
- single-flight gate test verifies overlapping table analysis is rejected until the active request ends
- Xcode Debug arm64 build succeeded with code signing disabled
- `git diff --check` passed

## Scope

This PR is based directly on current `main` and does not duplicate the open OCR fallback, pasteboard, or stateful-workflow PRs.